### PR TITLE
Add unit tests for additional models

### DIFF
--- a/test/model/model_account_create_test.go
+++ b/test/model/model_account_create_test.go
@@ -1,0 +1,127 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// helper to build example contact details
+func buildExampleContact() openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1("123 Example Road")
+	c.SetEmail("test@example.com")
+	c.SetFirstname("Jane")
+	c.SetLastname("Doe")
+	c.SetCountry("GB")
+	return *c
+}
+
+var exampleAccountID = "acc123"
+
+func TestNewAccountCreate(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleAccountID, model.GetAccountId())
+	assert.False(t, model.HasContact())
+	contact, ok := model.GetContactOk()
+	assert.False(t, ok)
+	assert.Nil(t, contact)
+}
+
+func TestNewAccountCreateWithDefaults(t *testing.T) {
+	model := openapiclient.NewAccountCreateWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetAccountId())
+	assert.False(t, model.HasContact())
+}
+
+func TestAccountCreateSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	model.SetAccountId("updated")
+	assert.Equal(t, "updated", model.GetAccountId())
+	id, ok := model.GetAccountIdOk()
+	require.True(t, ok)
+	if assert.NotNil(t, id) {
+		assert.Equal(t, "updated", *id)
+	}
+
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	assert.True(t, model.HasContact())
+	got := model.GetContact()
+	assert.Equal(t, contact, got)
+	gotPtr, ok := model.GetContactOk()
+	require.True(t, ok)
+	if assert.NotNil(t, gotPtr) {
+		assert.Equal(t, contact, *gotPtr)
+	}
+}
+
+func TestAccountCreateJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AccountCreate
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAccountID, unmarshalled.GetAccountId())
+	assert.True(t, unmarshalled.HasContact())
+	assert.Equal(t, contact, unmarshalled.GetContact())
+}
+
+func TestAccountCreateToMap(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "account_id") {
+		assert.Equal(t, exampleAccountID, m["account_id"])
+	}
+	if assert.Contains(t, m, "contact") {
+		if assert.NotNil(t, m["contact"]) {
+			assert.Equal(t, &contact, m["contact"])
+		}
+	}
+}
+
+func TestNullableAccountCreateGetSet(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	base.SetContact(buildExampleContact())
+	n := openapiclient.NullableAccountCreate{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAccountCreateUnset(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	n := openapiclient.NewNullableAccountCreate(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAccountCreateJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	base.SetContact(buildExampleContact())
+	n := openapiclient.NewNullableAccountCreate(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAccountCreate
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, base.GetAccountId(), newN.Get().GetAccountId())
+		assert.Equal(t, base.GetContact(), newN.Get().GetContact())
+	}
+}

--- a/test/model/model_account_status_test.go
+++ b/test/model/model_account_status_test.go
@@ -1,0 +1,98 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// example data used across tests
+var exampleStatus = "ACTIVE"
+
+func TestNewAccountStatus(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	require.NotNil(t, model)
+	assert.False(t, model.HasStatus())
+	assert.Equal(t, "", model.GetStatus())
+	val, ok := model.GetStatusOk()
+	assert.False(t, ok)
+	assert.Nil(t, val)
+}
+
+func TestNewAccountStatusWithDefaults(t *testing.T) {
+	model := openapiclient.NewAccountStatusWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasStatus())
+	assert.Equal(t, "", model.GetStatus())
+}
+
+func TestAccountStatusSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	assert.True(t, model.HasStatus())
+	assert.Equal(t, exampleStatus, model.GetStatus())
+	val, ok := model.GetStatusOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, exampleStatus, *val)
+	}
+}
+
+func TestAccountStatusJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AccountStatus
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasStatus())
+	assert.Equal(t, exampleStatus, unmarshalled.GetStatus())
+}
+
+func TestAccountStatusToMap(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "status") {
+		assert.Equal(t, &exampleStatus, m["status"])
+	}
+}
+
+func TestNullableAccountStatusGetSet(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	base.SetStatus(exampleStatus)
+	n := openapiclient.NullableAccountStatus{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAccountStatusUnset(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	n := openapiclient.NewNullableAccountStatus(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAccountStatusJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	base.SetStatus(exampleStatus)
+	n := openapiclient.NewNullableAccountStatus(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAccountStatus
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleStatus, newN.Get().GetStatus())
+	}
+}

--- a/test/model/model_acknowledgement_test.go
+++ b/test/model/model_acknowledgement_test.go
@@ -1,0 +1,132 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAckCode = "200"
+var exampleAckContext = "ctx1"
+var exampleAckIdentifier = "id1"
+var exampleAckMessage = "OK"
+
+func buildExampleAcknowledgement() *openapiclient.Acknowledgement {
+	a := openapiclient.NewAcknowledgement()
+	a.SetCode(exampleAckCode)
+	a.SetContext(exampleAckContext)
+	a.SetIdentifier(exampleAckIdentifier)
+	a.SetMessage(exampleAckMessage)
+	return a
+}
+
+func TestNewAcknowledgement(t *testing.T) {
+	model := openapiclient.NewAcknowledgement()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+	assert.False(t, model.HasContext())
+	assert.False(t, model.HasIdentifier())
+	assert.False(t, model.HasMessage())
+}
+
+func TestNewAcknowledgementWithDefaults(t *testing.T) {
+	model := openapiclient.NewAcknowledgementWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+	assert.False(t, model.HasContext())
+	assert.False(t, model.HasIdentifier())
+	assert.False(t, model.HasMessage())
+}
+
+func TestAcknowledgementSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAcknowledgement()
+	model.SetCode(exampleAckCode)
+	assert.True(t, model.HasCode())
+	assert.Equal(t, exampleAckCode, model.GetCode())
+	val, ok := model.GetCodeOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, exampleAckCode, *val)
+	}
+
+	model.SetContext(exampleAckContext)
+	assert.True(t, model.HasContext())
+	assert.Equal(t, exampleAckContext, model.GetContext())
+
+	model.SetIdentifier(exampleAckIdentifier)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleAckIdentifier, model.GetIdentifier())
+
+	model.SetMessage(exampleAckMessage)
+	assert.True(t, model.HasMessage())
+	assert.Equal(t, exampleAckMessage, model.GetMessage())
+}
+
+func TestAcknowledgementJSONRoundTrip(t *testing.T) {
+	model := buildExampleAcknowledgement()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Acknowledgement
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAckCode, unmarshalled.GetCode())
+	assert.Equal(t, exampleAckContext, unmarshalled.GetContext())
+	assert.Equal(t, exampleAckIdentifier, unmarshalled.GetIdentifier())
+	assert.Equal(t, exampleAckMessage, unmarshalled.GetMessage())
+}
+
+func TestAcknowledgementToMap(t *testing.T) {
+	model := buildExampleAcknowledgement()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "code") {
+		assert.Equal(t, &exampleAckCode, m["code"])
+	}
+	if assert.Contains(t, m, "context") {
+		assert.Equal(t, &exampleAckContext, m["context"])
+	}
+	if assert.Contains(t, m, "identifier") {
+		assert.Equal(t, &exampleAckIdentifier, m["identifier"])
+	}
+	if assert.Contains(t, m, "message") {
+		assert.Equal(t, &exampleAckMessage, m["message"])
+	}
+}
+
+func TestNullableAcknowledgementGetSet(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NullableAcknowledgement{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAcknowledgementUnset(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NewNullableAcknowledgement(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAcknowledgementJSONRoundTrip(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NewNullableAcknowledgement(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAcknowledgement
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAckCode, newN.Get().GetCode())
+		assert.Equal(t, exampleAckContext, newN.Get().GetContext())
+		assert.Equal(t, exampleAckIdentifier, newN.Get().GetIdentifier())
+		assert.Equal(t, exampleAckMessage, newN.Get().GetMessage())
+	}
+}

--- a/test/model/model_acl_check_request_test.go
+++ b/test/model/model_acl_check_request_test.go
@@ -1,0 +1,86 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAclRequestIP = "192.0.2.1"
+
+func TestNewAclCheckRequest(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleAclRequestIP, model.GetIp())
+}
+
+func TestNewAclCheckRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewAclCheckRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetIp())
+}
+
+func TestAclCheckRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	model.SetIp("203.0.113.5")
+	assert.Equal(t, "203.0.113.5", model.GetIp())
+	val, ok := model.GetIpOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, "203.0.113.5", *val)
+	}
+}
+
+func TestAclCheckRequestJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AclCheckRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAclRequestIP, unmarshalled.GetIp())
+}
+
+func TestAclCheckRequestToMap(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "ip") {
+		assert.Equal(t, exampleAclRequestIP, m["ip"])
+	}
+}
+
+func TestNullableAclCheckRequestGetSet(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NullableAclCheckRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAclCheckRequestUnset(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NewNullableAclCheckRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAclCheckRequestJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NewNullableAclCheckRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAclCheckRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAclRequestIP, newN.Get().GetIp())
+	}
+}

--- a/test/model/model_acl_check_response_model_test.go
+++ b/test/model/model_acl_check_response_model_test.go
@@ -1,0 +1,127 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAclName = "Public"
+var exampleAclCache = true
+var exampleAclIP = "192.0.2.1"
+var exampleAclProvider = "cloud"
+
+func buildExampleAclCheckResponse() *openapiclient.AclCheckResponseModel {
+	m := openapiclient.NewAclCheckResponseModel()
+	m.SetAcl(exampleAclName)
+	m.SetCache(exampleAclCache)
+	m.SetIp(exampleAclIP)
+	m.SetProvider(exampleAclProvider)
+	return m
+}
+
+func TestNewAclCheckResponseModel(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModel()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAcl())
+	assert.False(t, model.HasCache())
+	assert.False(t, model.HasIp())
+	assert.False(t, model.HasProvider())
+}
+
+func TestNewAclCheckResponseModelWithDefaults(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAcl())
+	assert.False(t, model.HasCache())
+	assert.False(t, model.HasIp())
+	assert.False(t, model.HasProvider())
+}
+
+func TestAclCheckResponseModelSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModel()
+	model.SetAcl(exampleAclName)
+	assert.True(t, model.HasAcl())
+	assert.Equal(t, exampleAclName, model.GetAcl())
+
+	model.SetCache(exampleAclCache)
+	assert.True(t, model.HasCache())
+	assert.Equal(t, exampleAclCache, model.GetCache())
+
+	model.SetIp(exampleAclIP)
+	assert.True(t, model.HasIp())
+	assert.Equal(t, exampleAclIP, model.GetIp())
+
+	model.SetProvider(exampleAclProvider)
+	assert.True(t, model.HasProvider())
+	assert.Equal(t, exampleAclProvider, model.GetProvider())
+}
+
+func TestAclCheckResponseModelJSONRoundTrip(t *testing.T) {
+	model := buildExampleAclCheckResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AclCheckResponseModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAclName, unmarshalled.GetAcl())
+	assert.Equal(t, exampleAclCache, unmarshalled.GetCache())
+	assert.Equal(t, exampleAclIP, unmarshalled.GetIp())
+	assert.Equal(t, exampleAclProvider, unmarshalled.GetProvider())
+}
+
+func TestAclCheckResponseModelToMap(t *testing.T) {
+	model := buildExampleAclCheckResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "acl") {
+		assert.Equal(t, &exampleAclName, m["acl"])
+	}
+	if assert.Contains(t, m, "cache") {
+		assert.Equal(t, &exampleAclCache, m["cache"])
+	}
+	if assert.Contains(t, m, "ip") {
+		assert.Equal(t, &exampleAclIP, m["ip"])
+	}
+	if assert.Contains(t, m, "provider") {
+		assert.Equal(t, &exampleAclProvider, m["provider"])
+	}
+}
+
+func TestNullableAclCheckResponseModelGetSet(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NullableAclCheckResponseModel{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAclCheckResponseModelUnset(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NewNullableAclCheckResponseModel(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAclCheckResponseModelJSONRoundTrip(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NewNullableAclCheckResponseModel(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAclCheckResponseModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAclName, newN.Get().GetAcl())
+		assert.Equal(t, exampleAclCache, newN.Get().GetCache())
+		assert.Equal(t, exampleAclIP, newN.Get().GetIp())
+		assert.Equal(t, exampleAclProvider, newN.Get().GetProvider())
+	}
+}

--- a/test/model/model_airline_advice_test.go
+++ b/test/model/model_airline_advice_test.go
@@ -1,0 +1,158 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleCarrierName = "Airline"
+var exampleTicketIssueCity = "London"
+var exampleTicketIssueDate = "2023-01-05"
+var exampleTicketIssueName = "Agency"
+var exampleTicketNo = "1234567890123"
+var exampleTransactionType = "TKT"
+var examplePassengerName = "John Doe"
+var exampleOriginalTicketNo = "9876543210987"
+var exampleNoAirSegments int32 = 2
+var exampleNumberInParty int32 = 1
+var exampleConjunctionIndicator = true
+var exampleEticketIndicator = false
+
+func buildExampleAdvice() *openapiclient.AirlineAdvice {
+	seg1 := buildExampleSegment()
+	seg2 := buildExampleSegment()
+	a := openapiclient.NewAirlineAdvice(exampleCarrierName, seg1, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	a.SetConjunctionTicketIndicator(exampleConjunctionIndicator)
+	a.SetEticketIndicator(exampleEticketIndicator)
+	a.SetNoAirSegments(exampleNoAirSegments)
+	a.SetNumberInParty(exampleNumberInParty)
+	a.SetOriginalTicketNo(exampleOriginalTicketNo)
+	a.SetPassengerName(examplePassengerName)
+	a.SetSegment2(seg2)
+	return a
+}
+
+func TestNewAirlineAdvice(t *testing.T) {
+	seg := buildExampleSegment()
+	model := openapiclient.NewAirlineAdvice(exampleCarrierName, seg, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleCarrierName, model.GetCarrierName())
+	assert.False(t, model.HasConjunctionTicketIndicator())
+	assert.False(t, model.HasEticketIndicator())
+	assert.False(t, model.HasNoAirSegments())
+	assert.False(t, model.HasNumberInParty())
+	assert.False(t, model.HasOriginalTicketNo())
+	assert.False(t, model.HasPassengerName())
+	assert.False(t, model.HasSegment2())
+	assert.False(t, model.HasSegment3())
+	assert.False(t, model.HasSegment4())
+}
+
+func TestNewAirlineAdviceWithDefaults(t *testing.T) {
+	model := openapiclient.NewAirlineAdviceWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetCarrierName())
+	assert.False(t, model.HasConjunctionTicketIndicator())
+}
+
+func TestAirlineAdviceSetGetCycle(t *testing.T) {
+	seg := buildExampleSegment()
+	model := openapiclient.NewAirlineAdvice(exampleCarrierName, seg, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	model.SetCarrierName("NewAir")
+	assert.Equal(t, "NewAir", model.GetCarrierName())
+
+	model.SetConjunctionTicketIndicator(exampleConjunctionIndicator)
+	assert.True(t, model.HasConjunctionTicketIndicator())
+	assert.Equal(t, exampleConjunctionIndicator, model.GetConjunctionTicketIndicator())
+
+	model.SetEticketIndicator(exampleEticketIndicator)
+	assert.True(t, model.HasEticketIndicator())
+	assert.Equal(t, exampleEticketIndicator, model.GetEticketIndicator())
+
+	model.SetNoAirSegments(exampleNoAirSegments)
+	assert.True(t, model.HasNoAirSegments())
+	assert.Equal(t, exampleNoAirSegments, model.GetNoAirSegments())
+
+	model.SetNumberInParty(exampleNumberInParty)
+	assert.True(t, model.HasNumberInParty())
+	assert.Equal(t, exampleNumberInParty, model.GetNumberInParty())
+
+	model.SetOriginalTicketNo(exampleOriginalTicketNo)
+	assert.True(t, model.HasOriginalTicketNo())
+	assert.Equal(t, exampleOriginalTicketNo, model.GetOriginalTicketNo())
+
+	model.SetPassengerName(examplePassengerName)
+	assert.True(t, model.HasPassengerName())
+	assert.Equal(t, examplePassengerName, model.GetPassengerName())
+
+	seg2 := buildExampleSegment()
+	model.SetSegment2(seg2)
+	assert.True(t, model.HasSegment2())
+	assert.Equal(t, seg2, model.GetSegment2())
+}
+
+func TestAirlineAdviceJSONRoundTrip(t *testing.T) {
+	model := buildExampleAdvice()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AirlineAdvice
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleCarrierName, unmarshalled.GetCarrierName())
+	assert.True(t, unmarshalled.HasConjunctionTicketIndicator())
+	assert.Equal(t, exampleConjunctionIndicator, unmarshalled.GetConjunctionTicketIndicator())
+	assert.True(t, unmarshalled.HasSegment2())
+}
+
+func TestAirlineAdviceToMap(t *testing.T) {
+	model := buildExampleAdvice()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "carrier_name") {
+		assert.Equal(t, exampleCarrierName, m["carrier_name"])
+	}
+	if assert.Contains(t, m, "conjunction_ticket_indicator") {
+		assert.Equal(t, &exampleConjunctionIndicator, m["conjunction_ticket_indicator"])
+	}
+	if assert.Contains(t, m, "segment2") {
+		if assert.NotNil(t, m["segment2"]) {
+			assert.Equal(t, model.GetSegment2(), *m["segment2"].(*openapiclient.AirlineSegment))
+		}
+	}
+}
+
+func TestNullableAirlineAdviceGetSet(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NullableAirlineAdvice{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAirlineAdviceUnset(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NewNullableAirlineAdvice(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAirlineAdviceJSONRoundTrip(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NewNullableAirlineAdvice(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAirlineAdvice
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleCarrierName, newN.Get().GetCarrierName())
+	}
+}

--- a/test/model/model_airline_segment_test.go
+++ b/test/model/model_airline_segment_test.go
@@ -1,0 +1,165 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleSegArrival = "LHR"
+var exampleSegCarrier = "BA"
+var exampleSegClass = "E"
+var exampleSegDate = "2023-01-01"
+var exampleSegDeparture = "JFK"
+var exampleSegFlight = "BA123"
+var exampleSegFare int32 = 100
+var exampleSegStop = "O"
+
+func buildExampleSegment() openapiclient.AirlineSegment {
+	s := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	s.SetDepartureLocationCode(exampleSegDeparture)
+	s.SetSegmentFare(exampleSegFare)
+	s.SetStopOverIndicator(exampleSegStop)
+	return *s
+}
+
+func TestNewAirlineSegment(t *testing.T) {
+	model := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleSegArrival, model.GetArrivalLocationCode())
+	assert.Equal(t, exampleSegCarrier, model.GetCarrierCode())
+	assert.False(t, model.HasDepartureLocationCode())
+	assert.False(t, model.HasSegmentFare())
+	assert.False(t, model.HasStopOverIndicator())
+}
+
+func TestNewAirlineSegmentWithDefaults(t *testing.T) {
+	model := openapiclient.NewAirlineSegmentWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetArrivalLocationCode())
+	assert.Equal(t, "", model.GetCarrierCode())
+	assert.False(t, model.HasDepartureLocationCode())
+	assert.False(t, model.HasSegmentFare())
+	assert.False(t, model.HasStopOverIndicator())
+}
+
+func TestAirlineSegmentSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	model.SetArrivalLocationCode("AAA")
+	assert.Equal(t, "AAA", model.GetArrivalLocationCode())
+	val, ok := model.GetArrivalLocationCodeOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, "AAA", *val)
+	}
+
+	model.SetCarrierCode("CC")
+	assert.Equal(t, "CC", model.GetCarrierCode())
+
+	model.SetClassServiceCode("B")
+	assert.Equal(t, "B", model.GetClassServiceCode())
+
+	model.SetDepartureDate("2023-02-01")
+	assert.Equal(t, "2023-02-01", model.GetDepartureDate())
+
+	model.SetDepartureLocationCode(exampleSegDeparture)
+	assert.True(t, model.HasDepartureLocationCode())
+	assert.Equal(t, exampleSegDeparture, model.GetDepartureLocationCode())
+
+	model.SetFlightNumber("FL001")
+	assert.Equal(t, "FL001", model.GetFlightNumber())
+
+	model.SetSegmentFare(exampleSegFare)
+	assert.True(t, model.HasSegmentFare())
+	assert.Equal(t, exampleSegFare, model.GetSegmentFare())
+
+	model.SetStopOverIndicator(exampleSegStop)
+	assert.True(t, model.HasStopOverIndicator())
+	assert.Equal(t, exampleSegStop, model.GetStopOverIndicator())
+}
+
+func TestAirlineSegmentJSONRoundTrip(t *testing.T) {
+	model := buildExampleSegment()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AirlineSegment
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleSegArrival, unmarshalled.GetArrivalLocationCode())
+	assert.Equal(t, exampleSegCarrier, unmarshalled.GetCarrierCode())
+	assert.Equal(t, exampleSegClass, unmarshalled.GetClassServiceCode())
+	assert.Equal(t, exampleSegDate, unmarshalled.GetDepartureDate())
+	assert.True(t, unmarshalled.HasDepartureLocationCode())
+	assert.Equal(t, exampleSegDeparture, unmarshalled.GetDepartureLocationCode())
+	assert.Equal(t, exampleSegFlight, unmarshalled.GetFlightNumber())
+	assert.True(t, unmarshalled.HasSegmentFare())
+	assert.Equal(t, exampleSegFare, unmarshalled.GetSegmentFare())
+	assert.True(t, unmarshalled.HasStopOverIndicator())
+	assert.Equal(t, exampleSegStop, unmarshalled.GetStopOverIndicator())
+}
+
+func TestAirlineSegmentToMap(t *testing.T) {
+	model := buildExampleSegment()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "arrival_location_code") {
+		assert.Equal(t, exampleSegArrival, m["arrival_location_code"])
+	}
+	if assert.Contains(t, m, "carrier_code") {
+		assert.Equal(t, exampleSegCarrier, m["carrier_code"])
+	}
+	if assert.Contains(t, m, "class_service_code") {
+		assert.Equal(t, exampleSegClass, m["class_service_code"])
+	}
+	if assert.Contains(t, m, "departure_date") {
+		assert.Equal(t, exampleSegDate, m["departure_date"])
+	}
+	if assert.Contains(t, m, "departure_location_code") {
+		assert.Equal(t, &exampleSegDeparture, m["departure_location_code"])
+	}
+	if assert.Contains(t, m, "flight_number") {
+		assert.Equal(t, exampleSegFlight, m["flight_number"])
+	}
+	if assert.Contains(t, m, "segment_fare") {
+		assert.Equal(t, &exampleSegFare, m["segment_fare"])
+	}
+	if assert.Contains(t, m, "stop_over_indicator") {
+		assert.Equal(t, &exampleSegStop, m["stop_over_indicator"])
+	}
+}
+
+func TestNullableAirlineSegmentGetSet(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NullableAirlineSegment{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableAirlineSegmentUnset(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NewNullableAirlineSegment(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAirlineSegmentJSONRoundTrip(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NewNullableAirlineSegment(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAirlineSegment
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleSegArrival, newN.Get().GetArrivalLocationCode())
+		assert.Equal(t, exampleSegCarrier, newN.Get().GetCarrierCode())
+	}
+}

--- a/test/model/model_auth_reference_test.go
+++ b/test/model/model_auth_reference_test.go
@@ -1,0 +1,189 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleAuthRefAmount = "12.34"
+var exampleAuthRefAmountValue int32 = 1234
+var exampleAuthRefAtrn = "ATR123"
+var exampleAuthRefAuthcode = "AUTHCODE"
+var exampleAuthRefBatchno = "BN1"
+var exampleAuthRefCurrency = "GBP"
+var exampleAuthRefDatetime = time.Date(2023, time.January, 2, 15, 4, 5, 0, time.UTC)
+var exampleAuthRefIdentifier = "ID42"
+var exampleAuthRefMaskedpan = "411111******1111"
+var exampleAuthRefMerchantid int32 = 100
+var exampleAuthRefResult = "OK"
+var exampleAuthRefTransStatus = "Approved"
+var exampleAuthRefTransType = "SALE"
+var exampleAuthRefTransno int32 = 99
+
+func buildExampleAuthReference() *openapiclient.AuthReference {
+    a := openapiclient.NewAuthReference()
+    a.SetAmount(exampleAuthRefAmount)
+    a.SetAmountValue(exampleAuthRefAmountValue)
+    a.SetAtrn(exampleAuthRefAtrn)
+    a.SetAuthcode(exampleAuthRefAuthcode)
+    a.SetBatchno(exampleAuthRefBatchno)
+    a.SetCurrency(exampleAuthRefCurrency)
+    a.SetDatetime(exampleAuthRefDatetime)
+    a.SetIdentifier(exampleAuthRefIdentifier)
+    a.SetMaskedpan(exampleAuthRefMaskedpan)
+    a.SetMerchantid(exampleAuthRefMerchantid)
+    a.SetResult(exampleAuthRefResult)
+    a.SetTransStatus(exampleAuthRefTransStatus)
+    a.SetTransType(exampleAuthRefTransType)
+    a.SetTransno(exampleAuthRefTransno)
+    return a
+}
+
+func TestNewAuthReference(t *testing.T) {
+    model := openapiclient.NewAuthReference()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAmountValue())
+    assert.False(t, model.HasAtrn())
+    assert.False(t, model.HasAuthcode())
+    assert.False(t, model.HasBatchno())
+    assert.False(t, model.HasCurrency())
+    assert.False(t, model.HasDatetime())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasMaskedpan())
+    assert.False(t, model.HasMerchantid())
+    assert.False(t, model.HasResult())
+    assert.False(t, model.HasTransStatus())
+    assert.False(t, model.HasTransType())
+    assert.False(t, model.HasTransno())
+}
+
+func TestNewAuthReferenceWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthReferenceWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAmountValue())
+}
+
+func TestAuthReferenceSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthReference()
+    model.SetAmount(exampleAuthRefAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleAuthRefAmount, model.GetAmount())
+
+    model.SetAmountValue(exampleAuthRefAmountValue)
+    assert.True(t, model.HasAmountValue())
+    assert.Equal(t, exampleAuthRefAmountValue, model.GetAmountValue())
+
+    model.SetAtrn(exampleAuthRefAtrn)
+    assert.True(t, model.HasAtrn())
+    assert.Equal(t, exampleAuthRefAtrn, model.GetAtrn())
+
+    model.SetAuthcode(exampleAuthRefAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleAuthRefAuthcode, model.GetAuthcode())
+
+    model.SetBatchno(exampleAuthRefBatchno)
+    assert.True(t, model.HasBatchno())
+    assert.Equal(t, exampleAuthRefBatchno, model.GetBatchno())
+
+    model.SetCurrency(exampleAuthRefCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleAuthRefCurrency, model.GetCurrency())
+
+    model.SetDatetime(exampleAuthRefDatetime)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleAuthRefDatetime, model.GetDatetime())
+
+    model.SetIdentifier(exampleAuthRefIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleAuthRefIdentifier, model.GetIdentifier())
+
+    model.SetMaskedpan(exampleAuthRefMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    assert.Equal(t, exampleAuthRefMaskedpan, model.GetMaskedpan())
+
+    model.SetMerchantid(exampleAuthRefMerchantid)
+    assert.True(t, model.HasMerchantid())
+    assert.Equal(t, exampleAuthRefMerchantid, model.GetMerchantid())
+
+    model.SetResult(exampleAuthRefResult)
+    assert.True(t, model.HasResult())
+    assert.Equal(t, exampleAuthRefResult, model.GetResult())
+
+    model.SetTransStatus(exampleAuthRefTransStatus)
+    assert.True(t, model.HasTransStatus())
+    assert.Equal(t, exampleAuthRefTransStatus, model.GetTransStatus())
+
+    model.SetTransType(exampleAuthRefTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleAuthRefTransType, model.GetTransType())
+
+    model.SetTransno(exampleAuthRefTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleAuthRefTransno, model.GetTransno())
+}
+
+func TestAuthReferenceJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthReference()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthReference
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAmount())
+    assert.Equal(t, exampleAuthRefAmount, unmarshalled.GetAmount())
+    assert.True(t, unmarshalled.HasTransno())
+    assert.Equal(t, exampleAuthRefTransno, unmarshalled.GetTransno())
+}
+
+func TestAuthReferenceToMap(t *testing.T) {
+    model := buildExampleAuthReference()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleAuthRefAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "transno") {
+        assert.Equal(t, &exampleAuthRefTransno, m["transno"])
+    }
+}
+
+func TestNullableAuthReferenceGetSet(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NullableAuthReference{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthReferenceUnset(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NewNullableAuthReference(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthReferenceJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NewNullableAuthReference(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthReference
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleAuthRefAtrn, newN.Get().GetAtrn())
+    }
+}
+

--- a/test/model/model_auth_references_test.go
+++ b/test/model/model_auth_references_test.go
@@ -1,0 +1,94 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func buildExampleAuthReferences() *openapiclient.AuthReferences {
+    ref := buildExampleAuthReference()
+    a := openapiclient.NewAuthReferences()
+    a.SetAuths([]openapiclient.AuthReference{*ref})
+    return a
+}
+
+func TestNewAuthReferences(t *testing.T) {
+    model := openapiclient.NewAuthReferences()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAuths())
+}
+
+func TestNewAuthReferencesWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthReferencesWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAuths())
+}
+
+func TestAuthReferencesSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthReferences()
+    ref := buildExampleAuthReference()
+    model.SetAuths([]openapiclient.AuthReference{*ref})
+    assert.True(t, model.HasAuths())
+    assert.Equal(t, 1, len(model.GetAuths()))
+}
+
+func TestAuthReferencesJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthReferences()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthReferences
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAuths())
+    assert.Equal(t, 1, len(unmarshalled.GetAuths()))
+}
+
+func TestAuthReferencesToMap(t *testing.T) {
+    model := buildExampleAuthReferences()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "auths") {
+        if assert.Len(t, m["auths"], 1) {
+            first := m["auths"].([]openapiclient.AuthReference)[0]
+            assert.Equal(t, exampleAuthRefAtrn, first.GetAtrn())
+        }
+    }
+}
+
+func TestNullableAuthReferencesGetSet(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NullableAuthReferences{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthReferencesUnset(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NewNullableAuthReferences(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthReferencesJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NewNullableAuthReferences(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthReferences
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, 1, len(newN.Get().GetAuths()))
+    }
+}
+

--- a/test/model/model_auth_request_test.go
+++ b/test/model/model_auth_request_test.go
@@ -1,0 +1,214 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleReqAmount int32 = 10000
+var exampleReqCard = "4111111111111111"
+var exampleReqExpMonth int32 = 12
+var exampleReqExpYear int32 = 25
+var exampleReqIdentifier = "REQ123"
+var exampleReqMerchantID int32 = 999
+var exampleReqAvsPostcodePolicy = "1"
+var exampleReqCsc = "999"
+var exampleReqCscPolicy = "2"
+var exampleReqCurrency = "USD"
+var exampleReqDuplicatePolicy = "1"
+var exampleReqMatchAvsa = "2"
+var exampleReqNameOnCard = "John Doe"
+var exampleReqTransInfo = "info"
+var exampleReqTransType = "SALE"
+var exampleReqTags = []string{"one", "two"}
+
+func buildExampleEventData() openapiclient.EventDataModel {
+    e := openapiclient.NewEventDataModel()
+    e.SetEventId("EVT")
+    return *e
+}
+
+func buildExampleExternalMPI() openapiclient.ExternalMPI {
+    e := openapiclient.NewExternalMPI()
+    e.SetEnrolled("Y")
+    return *e
+}
+
+func buildExampleMcc6012() openapiclient.MCC6012 {
+    m := openapiclient.NewMCC6012()
+    m.SetRecipientLastname("Smith")
+    return *m
+}
+
+func buildExampleThreeDSecure() openapiclient.ThreeDSecure {
+    t := openapiclient.NewThreeDSecure()
+    t.SetTdsPolicy("1")
+    return *t
+}
+
+func buildExampleAuthRequest() *openapiclient.AuthRequest {
+    r := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    r.SetAirlineData(*buildExampleAdvice())
+    r.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+    r.SetBillTo(buildExampleContact())
+    r.SetCsc(exampleReqCsc)
+    r.SetCscPolicy(exampleReqCscPolicy)
+    r.SetCurrency(exampleReqCurrency)
+    r.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+    r.SetEventManagement(buildExampleEventData())
+    r.SetExternalMpi(buildExampleExternalMPI())
+    r.SetMatchAvsa(exampleReqMatchAvsa)
+    r.SetMcc6012(buildExampleMcc6012())
+    r.SetNameOnCard(exampleReqNameOnCard)
+    r.SetShipTo(buildExampleContact())
+    r.SetTag(exampleReqTags)
+    r.SetThreedsecure(buildExampleThreeDSecure())
+    r.SetTransInfo(exampleReqTransInfo)
+    r.SetTransType(exampleReqTransType)
+    return r
+}
+
+func TestNewAuthRequest(t *testing.T) {
+    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleReqAmount, model.GetAmount())
+    assert.Equal(t, exampleReqCard, model.GetCardnumber())
+    assert.False(t, model.HasAirlineData())
+    assert.False(t, model.HasAvsPostcodePolicy())
+    assert.False(t, model.HasBillTo())
+    assert.False(t, model.HasCsc())
+}
+
+func TestNewAuthRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+    assert.Equal(t, "", model.GetCardnumber())
+    assert.False(t, model.HasAirlineData())
+}
+
+func TestAuthRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    model.SetAirlineData(*buildExampleAdvice())
+    assert.True(t, model.HasAirlineData())
+
+    model.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+    assert.True(t, model.HasAvsPostcodePolicy())
+    assert.Equal(t, exampleReqAvsPostcodePolicy, model.GetAvsPostcodePolicy())
+
+    model.SetBillTo(buildExampleContact())
+    assert.True(t, model.HasBillTo())
+
+    model.SetCsc(exampleReqCsc)
+    assert.True(t, model.HasCsc())
+    assert.Equal(t, exampleReqCsc, model.GetCsc())
+
+    model.SetCscPolicy(exampleReqCscPolicy)
+    assert.True(t, model.HasCscPolicy())
+    assert.Equal(t, exampleReqCscPolicy, model.GetCscPolicy())
+
+    model.SetCurrency(exampleReqCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleReqCurrency, model.GetCurrency())
+
+    model.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+    assert.True(t, model.HasDuplicatePolicy())
+    assert.Equal(t, exampleReqDuplicatePolicy, model.GetDuplicatePolicy())
+
+    model.SetEventManagement(buildExampleEventData())
+    assert.True(t, model.HasEventManagement())
+
+    model.SetExternalMpi(buildExampleExternalMPI())
+    assert.True(t, model.HasExternalMpi())
+
+    model.SetMatchAvsa(exampleReqMatchAvsa)
+    assert.True(t, model.HasMatchAvsa())
+    assert.Equal(t, exampleReqMatchAvsa, model.GetMatchAvsa())
+
+    model.SetMcc6012(buildExampleMcc6012())
+    assert.True(t, model.HasMcc6012())
+
+    model.SetNameOnCard(exampleReqNameOnCard)
+    assert.True(t, model.HasNameOnCard())
+    assert.Equal(t, exampleReqNameOnCard, model.GetNameOnCard())
+
+    model.SetShipTo(buildExampleContact())
+    assert.True(t, model.HasShipTo())
+
+    model.SetTag(exampleReqTags)
+    assert.True(t, model.HasTag())
+    assert.Equal(t, exampleReqTags, model.GetTag())
+
+    model.SetThreedsecure(buildExampleThreeDSecure())
+    assert.True(t, model.HasThreedsecure())
+
+    model.SetTransInfo(exampleReqTransInfo)
+    assert.True(t, model.HasTransInfo())
+    assert.Equal(t, exampleReqTransInfo, model.GetTransInfo())
+
+    model.SetTransType(exampleReqTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleReqTransType, model.GetTransType())
+}
+
+func TestAuthRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleReqAmount, unmarshalled.GetAmount())
+    assert.True(t, unmarshalled.HasTag())
+    assert.Equal(t, exampleReqTransType, unmarshalled.GetTransType())
+}
+
+func TestAuthRequestToMap(t *testing.T) {
+    model := buildExampleAuthRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleReqAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "tag") {
+        assert.Equal(t, exampleReqTags, m["tag"])
+    }
+}
+
+func TestNullableAuthRequestGetSet(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NullableAuthRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthRequestUnset(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NewNullableAuthRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NewNullableAuthRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleReqIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_auth_response_test.go
+++ b/test/model/model_auth_response_test.go
@@ -1,0 +1,246 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleRespAmount int32 = 1000
+var exampleRespAtrn = "ATRN"
+var exampleRespAtsd = "A1"
+var exampleRespAuthcode = "ACODE"
+var exampleRespAuthenResult = "Y"
+var exampleRespAuthorised = true
+var exampleRespAvsResult = "Y"
+var exampleRespBinCommercial = true
+var exampleRespBinDebit = true
+var exampleRespBinDescription = "DEBIT"
+var exampleRespCavv = "CAVV"
+var exampleRespContext = "CTX"
+var exampleRespCscResult = "M"
+var exampleRespCurrency = "GBP"
+var exampleRespDatetime = time.Date(2023, time.March, 5, 10, 0, 0, 0, time.UTC)
+var exampleRespEci = "05"
+var exampleRespIdentifier = "ID1"
+var exampleRespLive = true
+var exampleRespMaskedpan = "411111******1111"
+var exampleRespMerchantid int32 = 321
+var exampleRespResult int32 = 1
+var exampleRespResultCode = "A"
+var exampleRespResultMessage = "Approved"
+var exampleRespScheme = "VISA"
+var exampleRespSchemeId = "VIS"
+var exampleRespSchemeLogo = "logo"
+var exampleRespSha256 = "hash"
+var exampleRespTransStatus = "APPROVED"
+var exampleRespTransno int32 = 55
+
+func buildExampleAuthResponse() *openapiclient.AuthResponse {
+    r := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    r.SetAmount(exampleRespAmount)
+    r.SetAtrn(exampleRespAtrn)
+    r.SetAtsd(exampleRespAtsd)
+    r.SetAuthcode(exampleRespAuthcode)
+    r.SetAuthenResult(exampleRespAuthenResult)
+    r.SetAuthorised(exampleRespAuthorised)
+    r.SetAvsResult(exampleRespAvsResult)
+    r.SetBinCommercial(exampleRespBinCommercial)
+    r.SetBinDebit(exampleRespBinDebit)
+    r.SetBinDescription(exampleRespBinDescription)
+    r.SetCavv(exampleRespCavv)
+    r.SetContext(exampleRespContext)
+    r.SetCscResult(exampleRespCscResult)
+    r.SetCurrency(exampleRespCurrency)
+    r.SetDatetime(exampleRespDatetime)
+    r.SetEci(exampleRespEci)
+    r.SetIdentifier(exampleRespIdentifier)
+    r.SetLive(exampleRespLive)
+    r.SetMaskedpan(exampleRespMaskedpan)
+    r.SetScheme(exampleRespScheme)
+    r.SetSchemeId(exampleRespSchemeId)
+    r.SetSchemeLogo(exampleRespSchemeLogo)
+    r.SetSha256(exampleRespSha256)
+    r.SetTransStatus(exampleRespTransStatus)
+    r.SetTransno(exampleRespTransno)
+    return r
+}
+
+func TestNewAuthResponse(t *testing.T) {
+    model := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleRespMerchantid, model.GetMerchantid())
+    assert.Equal(t, exampleRespResult, model.GetResult())
+    assert.False(t, model.HasAmount())
+}
+
+func TestNewAuthResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetMerchantid())
+    assert.False(t, model.HasAmount())
+}
+
+func TestAuthResponseSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    model.SetAmount(exampleRespAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleRespAmount, model.GetAmount())
+
+    model.SetAtrn(exampleRespAtrn)
+    assert.True(t, model.HasAtrn())
+    assert.Equal(t, exampleRespAtrn, model.GetAtrn())
+
+    model.SetAtsd(exampleRespAtsd)
+    assert.True(t, model.HasAtsd())
+    assert.Equal(t, exampleRespAtsd, model.GetAtsd())
+
+    model.SetAuthcode(exampleRespAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleRespAuthcode, model.GetAuthcode())
+
+    model.SetAuthenResult(exampleRespAuthenResult)
+    assert.True(t, model.HasAuthenResult())
+    assert.Equal(t, exampleRespAuthenResult, model.GetAuthenResult())
+
+    model.SetAuthorised(exampleRespAuthorised)
+    assert.True(t, model.HasAuthorised())
+    assert.Equal(t, exampleRespAuthorised, model.GetAuthorised())
+
+    model.SetAvsResult(exampleRespAvsResult)
+    assert.True(t, model.HasAvsResult())
+    assert.Equal(t, exampleRespAvsResult, model.GetAvsResult())
+
+    model.SetBinCommercial(exampleRespBinCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleRespBinCommercial, model.GetBinCommercial())
+
+    model.SetBinDebit(exampleRespBinDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleRespBinDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleRespBinDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleRespBinDescription, model.GetBinDescription())
+
+    model.SetCavv(exampleRespCavv)
+    assert.True(t, model.HasCavv())
+    assert.Equal(t, exampleRespCavv, model.GetCavv())
+
+    model.SetContext(exampleRespContext)
+    assert.True(t, model.HasContext())
+    assert.Equal(t, exampleRespContext, model.GetContext())
+
+    model.SetCscResult(exampleRespCscResult)
+    assert.True(t, model.HasCscResult())
+    assert.Equal(t, exampleRespCscResult, model.GetCscResult())
+
+    model.SetCurrency(exampleRespCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleRespCurrency, model.GetCurrency())
+
+    model.SetDatetime(exampleRespDatetime)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleRespDatetime, model.GetDatetime())
+
+    model.SetEci(exampleRespEci)
+    assert.True(t, model.HasEci())
+    assert.Equal(t, exampleRespEci, model.GetEci())
+
+    model.SetIdentifier(exampleRespIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleRespIdentifier, model.GetIdentifier())
+
+    model.SetLive(exampleRespLive)
+    assert.True(t, model.HasLive())
+    assert.Equal(t, exampleRespLive, model.GetLive())
+
+    model.SetMaskedpan(exampleRespMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    assert.Equal(t, exampleRespMaskedpan, model.GetMaskedpan())
+
+    model.SetScheme(exampleRespScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleRespScheme, model.GetScheme())
+
+    model.SetSchemeId(exampleRespSchemeId)
+    assert.True(t, model.HasSchemeId())
+    assert.Equal(t, exampleRespSchemeId, model.GetSchemeId())
+
+    model.SetSchemeLogo(exampleRespSchemeLogo)
+    assert.True(t, model.HasSchemeLogo())
+    assert.Equal(t, exampleRespSchemeLogo, model.GetSchemeLogo())
+
+    model.SetSha256(exampleRespSha256)
+    assert.True(t, model.HasSha256())
+    assert.Equal(t, exampleRespSha256, model.GetSha256())
+
+    model.SetTransStatus(exampleRespTransStatus)
+    assert.True(t, model.HasTransStatus())
+    assert.Equal(t, exampleRespTransStatus, model.GetTransStatus())
+
+    model.SetTransno(exampleRespTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleRespTransno, model.GetTransno())
+}
+
+func TestAuthResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleRespResultCode, unmarshalled.GetResultCode())
+    assert.True(t, unmarshalled.HasAmount())
+}
+
+func TestAuthResponseToMap(t *testing.T) {
+    model := buildExampleAuthResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleRespAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "merchantid") {
+        assert.Equal(t, exampleRespMerchantid, m["merchantid"])
+    }
+}
+
+func TestNullableAuthResponseGetSet(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NullableAuthResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthResponseUnset(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NewNullableAuthResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NewNullableAuthResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleRespResultMessage, newN.Get().GetResultMessage())
+    }
+}
+

--- a/test/model/model_batch_report_request_test.go
+++ b/test/model/model_batch_report_request_test.go
@@ -1,0 +1,102 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBRRBatchId int32 = 99
+var exampleBRRClientAccountId = "clientA"
+
+func buildExampleBatchReportRequest() *openapiclient.BatchReportRequest {
+    r := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    r.SetClientAccountId(exampleBRRClientAccountId)
+    return r
+}
+
+func TestNewBatchReportRequest(t *testing.T) {
+    model := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBRRBatchId, model.GetBatchId())
+    assert.False(t, model.HasClientAccountId())
+}
+
+func TestNewBatchReportRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchReportRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetBatchId())
+}
+
+func TestBatchReportRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    model.SetClientAccountId(exampleBRRClientAccountId)
+    assert.True(t, model.HasClientAccountId())
+    assert.Equal(t, exampleBRRClientAccountId, model.GetClientAccountId())
+    val, ok := model.GetClientAccountIdOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBRRClientAccountId, *val)
+    }
+}
+
+func TestBatchReportRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchReportRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchReportRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBRRBatchId, unmarshalled.GetBatchId())
+    assert.True(t, unmarshalled.HasClientAccountId())
+    assert.Equal(t, exampleBRRClientAccountId, unmarshalled.GetClientAccountId())
+}
+
+func TestBatchReportRequestToMap(t *testing.T) {
+    model := buildExampleBatchReportRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_id") {
+        assert.Equal(t, exampleBRRBatchId, m["batch_id"])
+    }
+    if assert.Contains(t, m, "client_account_id") {
+        assert.Equal(t, &exampleBRRClientAccountId, m["client_account_id"])
+    }
+}
+
+func TestNullableBatchReportRequestGetSet(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NullableBatchReportRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchReportRequestUnset(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NewNullableBatchReportRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchReportRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NewNullableBatchReportRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchReportRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBRRClientAccountId, newN.Get().GetClientAccountId())
+    }
+}
+

--- a/test/model/model_batch_report_response_model_test.go
+++ b/test/model/model_batch_report_response_model_test.go
@@ -1,0 +1,153 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBRRAmount int32 = 1000
+var exampleBRRBatchDate = "2023-02-01T15:04:05Z"
+var exampleBRRBatchId int32 = 55
+var exampleBRRBatchStatus = "COMPLETE"
+var exampleBRRClientAccountId = "clientB"
+
+var exampleResAccountId = "acc123"
+var exampleResAmount int32 = 10
+var exampleResAuthcode = "AUTH1"
+var exampleResDatetime = time.Date(2023, time.March, 4, 5, 6, 7, 0, time.UTC)
+var exampleResIdentifier = "id99"
+var exampleResMaskedpan = "411111******1111"
+var exampleResMerchantid int32 = 77
+var exampleResMessage = "Approved"
+var exampleResResult int32 = 1
+var exampleResResultCode = "OK"
+var exampleResScheme = "VISA"
+var exampleResSchemeId = "VI"
+var exampleResSchemeLogo = "logo"
+var exampleResTransno int32 = 101
+
+func buildExampleBatchTransactionResult() openapiclient.BatchTransactionResultModel {
+    r := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    r.SetAmount(exampleResAmount)
+    r.SetAuthcode(exampleResAuthcode)
+    r.SetDatetime(exampleResDatetime)
+    r.SetMaskedpan(exampleResMaskedpan)
+    r.SetScheme(exampleResScheme)
+    r.SetSchemeId(exampleResSchemeId)
+    r.SetSchemeLogo(exampleResSchemeLogo)
+    r.SetTransno(exampleResTransno)
+    return *r
+}
+
+func buildExampleBatchReportResponseModel() *openapiclient.BatchReportResponseModel {
+    tr := buildExampleBatchTransactionResult()
+    m := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    return m
+}
+
+func TestNewBatchReportResponseModel(t *testing.T) {
+    tr := buildExampleBatchTransactionResult()
+    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBRRAmount, model.GetAmount())
+    assert.Equal(t, exampleBRRBatchDate, model.GetBatchDate())
+    assert.Equal(t, exampleBRRBatchId, model.GetBatchId())
+    assert.Equal(t, exampleBRRBatchStatus, model.GetBatchStatus())
+    assert.Equal(t, exampleBRRClientAccountId, model.GetClientAccountId())
+    assert.Equal(t, 1, len(model.GetTransactions()))
+}
+
+func TestNewBatchReportResponseModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchReportResponseModelWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+    assert.Equal(t, "", model.GetBatchDate())
+    assert.Equal(t, int32(0), model.GetBatchId())
+    assert.Equal(t, "", model.GetBatchStatus())
+    assert.Equal(t, "", model.GetClientAccountId())
+    assert.Equal(t, 0, len(model.GetTransactions()))
+}
+
+func TestBatchReportResponseModelSetGetCycle(t *testing.T) {
+    tr := buildExampleBatchTransactionResult()
+    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    model.SetAmount(2000)
+    assert.Equal(t, int32(2000), model.GetAmount())
+    model.SetBatchDate("2024-01-01")
+    assert.Equal(t, "2024-01-01", model.GetBatchDate())
+    model.SetBatchId(66)
+    assert.Equal(t, int32(66), model.GetBatchId())
+    model.SetBatchStatus("QUEUED")
+    assert.Equal(t, "QUEUED", model.GetBatchStatus())
+    model.SetClientAccountId("other")
+    assert.Equal(t, "other", model.GetClientAccountId())
+    model.SetTransactions([]openapiclient.BatchTransactionResultModel{tr, tr})
+    assert.Equal(t, 2, len(model.GetTransactions()))
+}
+
+func TestBatchReportResponseModelJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchReportResponseModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchReportResponseModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBRRAmount, unmarshalled.GetAmount())
+    assert.Equal(t, exampleBRRBatchDate, unmarshalled.GetBatchDate())
+    assert.Equal(t, exampleBRRBatchStatus, unmarshalled.GetBatchStatus())
+    assert.Equal(t, 1, len(unmarshalled.GetTransactions()))
+}
+
+func TestBatchReportResponseModelToMap(t *testing.T) {
+    model := buildExampleBatchReportResponseModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleBRRAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "batch_status") {
+        assert.Equal(t, exampleBRRBatchStatus, m["batch_status"])
+    }
+    if assert.Contains(t, m, "transactions") {
+        assert.Equal(t, 1, len(m["transactions"].([]openapiclient.BatchTransactionResultModel)))
+    }
+}
+
+func TestNullableBatchReportResponseModelGetSet(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NullableBatchReportResponseModel{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchReportResponseModelUnset(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NewNullableBatchReportResponseModel(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchReportResponseModelJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NewNullableBatchReportResponseModel(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchReportResponseModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBRRBatchStatus, newN.Get().GetBatchStatus())
+    }
+}
+

--- a/test/model/model_batch_test.go
+++ b/test/model/model_batch_test.go
@@ -1,0 +1,106 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBatchDate = "2023-01-01"
+var exampleBatchId int32 = 42
+var exampleBatchStatus = "QUEUED"
+
+func buildExampleBatch() *openapiclient.Batch {
+    b := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    b.SetBatchId(exampleBatchId)
+    return b
+}
+
+func TestNewBatch(t *testing.T) {
+    model := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBatchDate, model.GetBatchDate())
+    assert.Equal(t, exampleBatchStatus, model.GetBatchStatus())
+    assert.False(t, model.HasBatchId())
+}
+
+func TestNewBatchWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetBatchDate())
+    assert.Equal(t, "", model.GetBatchStatus())
+}
+
+func TestBatchSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    model.SetBatchDate("2023-02-02")
+    assert.Equal(t, "2023-02-02", model.GetBatchDate())
+
+    model.SetBatchId(exampleBatchId)
+    assert.True(t, model.HasBatchId())
+    assert.Equal(t, exampleBatchId, model.GetBatchId())
+
+    model.SetBatchStatus("COMPLETE")
+    assert.Equal(t, "COMPLETE", model.GetBatchStatus())
+}
+
+func TestBatchJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatch()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Batch
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBatchDate, unmarshalled.GetBatchDate())
+    assert.True(t, unmarshalled.HasBatchId())
+    assert.Equal(t, exampleBatchId, unmarshalled.GetBatchId())
+}
+
+func TestBatchToMap(t *testing.T) {
+    model := buildExampleBatch()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_date") {
+        assert.Equal(t, exampleBatchDate, m["batch_date"])
+    }
+    if assert.Contains(t, m, "batch_status") {
+        assert.Equal(t, exampleBatchStatus, m["batch_status"])
+    }
+}
+
+func TestNullableBatchGetSet(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NullableBatch{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchUnset(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NewNullableBatch(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NewNullableBatch(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatch
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBatchStatus, newN.Get().GetBatchStatus())
+    }
+}
+

--- a/test/model/model_batch_transaction_report_request_test.go
+++ b/test/model/model_batch_transaction_report_request_test.go
@@ -1,0 +1,121 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTRRMaxResults int32 = 20
+var exampleBTRRNextToken = "token"
+var exampleBTRROrderBy = "trans_no"
+
+func buildExampleBatchTransactionReportRequest() *openapiclient.BatchTransactionReportRequest {
+    r := openapiclient.NewBatchTransactionReportRequest()
+    r.SetMaxResults(exampleBTRRMaxResults)
+    r.SetNextToken(exampleBTRRNextToken)
+    r.SetOrderBy(exampleBTRROrderBy)
+    return r
+}
+
+func TestNewBatchTransactionReportRequest(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasMaxResults())
+    assert.False(t, model.HasNextToken())
+    assert.False(t, model.HasOrderBy())
+}
+
+func TestNewBatchTransactionReportRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasMaxResults())
+    assert.False(t, model.HasNextToken())
+    assert.False(t, model.HasOrderBy())
+}
+
+func TestBatchTransactionReportRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequest()
+    model.SetMaxResults(exampleBTRRMaxResults)
+    assert.True(t, model.HasMaxResults())
+    assert.Equal(t, exampleBTRRMaxResults, model.GetMaxResults())
+    val, ok := model.GetMaxResultsOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTRRMaxResults, *val)
+    }
+    model.SetNextToken(exampleBTRRNextToken)
+    assert.True(t, model.HasNextToken())
+    assert.Equal(t, exampleBTRRNextToken, model.GetNextToken())
+    val2, ok2 := model.GetNextTokenOk()
+    require.True(t, ok2)
+    if assert.NotNil(t, val2) {
+        assert.Equal(t, exampleBTRRNextToken, *val2)
+    }
+    model.SetOrderBy(exampleBTRROrderBy)
+    assert.True(t, model.HasOrderBy())
+    assert.Equal(t, exampleBTRROrderBy, model.GetOrderBy())
+}
+
+func TestBatchTransactionReportRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionReportRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionReportRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasMaxResults())
+    assert.Equal(t, exampleBTRRNextToken, unmarshalled.GetNextToken())
+}
+
+func TestBatchTransactionReportRequestToMap(t *testing.T) {
+    model := buildExampleBatchTransactionReportRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "maxResults") {
+        assert.Equal(t, &exampleBTRRMaxResults, m["maxResults"])
+    }
+    if assert.Contains(t, m, "nextToken") {
+        assert.Equal(t, &exampleBTRRNextToken, m["nextToken"])
+    }
+    if assert.Contains(t, m, "orderBy") {
+        assert.Equal(t, &exampleBTRROrderBy, m["orderBy"])
+    }
+}
+
+func TestNullableBatchTransactionReportRequestGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NullableBatchTransactionReportRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionReportRequestUnset(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NewNullableBatchTransactionReportRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionReportRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NewNullableBatchTransactionReportRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionReportRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTRRNextToken, newN.Get().GetNextToken())
+    }
+}
+

--- a/test/model/model_batch_transaction_report_response_test.go
+++ b/test/model/model_batch_transaction_report_response_test.go
@@ -1,0 +1,124 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTRRespCount int32 = 1
+var exampleBTRRespMaxResults int32 = 10
+var exampleBTRRespNextToken = "next"
+
+var exampleAuthRefMerchant int32 = 10
+
+func buildExampleAuthReferenceSimple() openapiclient.AuthReference {
+    a := openapiclient.NewAuthReference()
+    a.SetAuthcode("AC")
+    a.SetMerchantid(exampleAuthRefMerchant)
+    return *a
+}
+
+func buildExampleBatchTransactionReportResponse() *openapiclient.BatchTransactionReportResponse {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    r := openapiclient.NewBatchTransactionReportResponse(data)
+    r.SetCount(exampleBTRRespCount)
+    r.SetMaxResults(exampleBTRRespMaxResults)
+    r.SetNextToken(exampleBTRRespNextToken)
+    return r
+}
+
+func TestNewBatchTransactionReportResponse(t *testing.T) {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    model := openapiclient.NewBatchTransactionReportResponse(data)
+    require.NotNil(t, model)
+    assert.Equal(t, 1, len(model.GetData()))
+    assert.False(t, model.HasCount())
+}
+
+func TestNewBatchTransactionReportResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, 0, len(model.GetData()))
+}
+
+func TestBatchTransactionReportResponseSetGetCycle(t *testing.T) {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    model := openapiclient.NewBatchTransactionReportResponse(data)
+    model.SetCount(exampleBTRRespCount)
+    assert.True(t, model.HasCount())
+    assert.Equal(t, exampleBTRRespCount, model.GetCount())
+    val, ok := model.GetCountOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTRRespCount, *val)
+    }
+    model.SetMaxResults(exampleBTRRespMaxResults)
+    assert.True(t, model.HasMaxResults())
+    model.SetNextToken(exampleBTRRespNextToken)
+    assert.True(t, model.HasNextToken())
+}
+
+func TestBatchTransactionReportResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionReportResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionReportResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, 1, len(unmarshalled.GetData()))
+    assert.True(t, unmarshalled.HasCount())
+    assert.Equal(t, exampleBTRRespNextToken, unmarshalled.GetNextToken())
+}
+
+func TestBatchTransactionReportResponseToMap(t *testing.T) {
+    model := buildExampleBatchTransactionReportResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "data") {
+        assert.Equal(t, 1, len(m["data"].([]openapiclient.AuthReference)))
+    }
+    if assert.Contains(t, m, "count") {
+        assert.Equal(t, &exampleBTRRespCount, m["count"])
+    }
+    if assert.Contains(t, m, "nextToken") {
+        assert.Equal(t, &exampleBTRRespNextToken, m["nextToken"])
+    }
+}
+
+func TestNullableBatchTransactionReportResponseGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NullableBatchTransactionReportResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionReportResponseUnset(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NewNullableBatchTransactionReportResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionReportResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NewNullableBatchTransactionReportResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionReportResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTRRespCount, newN.Get().GetCount())
+    }
+}
+

--- a/test/model/model_batch_transaction_result_model_test.go
+++ b/test/model/model_batch_transaction_result_model_test.go
@@ -1,0 +1,152 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleResAccountId = "ac123"
+var exampleResAmount int32 = 10
+var exampleResAuthcode = "AUTH"
+var exampleResDatetime = time.Date(2023, time.January, 1, 2, 3, 4, 0, time.UTC)
+var exampleResIdentifier = "id001"
+var exampleResMaskedpan = "411111******1111"
+var exampleResMerchantid int32 = 44
+var exampleResMessage = "OK"
+var exampleResResult int32 = 1
+var exampleResResultCode = "A1"
+var exampleResScheme = "VISA"
+var exampleResSchemeId = "VI"
+var exampleResSchemeLogo = "logo"
+var exampleResTransno int32 = 99
+
+func buildExampleBatchTransactionResultModel() *openapiclient.BatchTransactionResultModel {
+    m := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    m.SetAmount(exampleResAmount)
+    m.SetAuthcode(exampleResAuthcode)
+    m.SetDatetime(exampleResDatetime)
+    m.SetMaskedpan(exampleResMaskedpan)
+    m.SetScheme(exampleResScheme)
+    m.SetSchemeId(exampleResSchemeId)
+    m.SetSchemeLogo(exampleResSchemeLogo)
+    m.SetTransno(exampleResTransno)
+    return m
+}
+
+func TestNewBatchTransactionResultModel(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleResAccountId, model.GetAccountId())
+    assert.Equal(t, exampleResIdentifier, model.GetIdentifier())
+    assert.Equal(t, exampleResMerchantid, model.GetMerchantid())
+    assert.Equal(t, exampleResMessage, model.GetMessage())
+    assert.Equal(t, exampleResResult, model.GetResult())
+    assert.Equal(t, exampleResResultCode, model.GetResultCode())
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAuthcode())
+    assert.False(t, model.HasDatetime())
+    assert.False(t, model.HasMaskedpan())
+    assert.False(t, model.HasScheme())
+    assert.False(t, model.HasSchemeId())
+    assert.False(t, model.HasSchemeLogo())
+    assert.False(t, model.HasTransno())
+}
+
+func TestNewBatchTransactionResultModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModelWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+    assert.Equal(t, "", model.GetIdentifier())
+    assert.Equal(t, int32(0), model.GetMerchantid())
+    assert.Equal(t, "", model.GetMessage())
+    assert.Equal(t, int32(0), model.GetResult())
+    assert.Equal(t, "", model.GetResultCode())
+}
+
+func TestBatchTransactionResultModelSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    model.SetAmount(exampleResAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleResAmount, model.GetAmount())
+    model.SetAuthcode(exampleResAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleResAuthcode, model.GetAuthcode())
+    model.SetDatetime(exampleResDatetime)
+    assert.True(t, model.HasDatetime())
+    model.SetMaskedpan(exampleResMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    model.SetScheme(exampleResScheme)
+    assert.True(t, model.HasScheme())
+    model.SetSchemeId(exampleResSchemeId)
+    assert.True(t, model.HasSchemeId())
+    model.SetSchemeLogo(exampleResSchemeLogo)
+    assert.True(t, model.HasSchemeLogo())
+    model.SetTransno(exampleResTransno)
+    assert.True(t, model.HasTransno())
+}
+
+func TestBatchTransactionResultModelJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionResultModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionResultModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleResAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasAmount())
+    assert.Equal(t, exampleResTransno, unmarshalled.GetTransno())
+}
+
+func TestBatchTransactionResultModelToMap(t *testing.T) {
+    model := buildExampleBatchTransactionResultModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleResAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleResAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "scheme_id") {
+        assert.Equal(t, &exampleResSchemeId, m["scheme_id"])
+    }
+}
+
+func TestNullableBatchTransactionResultModelGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NullableBatchTransactionResultModel{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionResultModelUnset(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NewNullableBatchTransactionResultModel(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionResultModelJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NewNullableBatchTransactionResultModel(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionResultModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleResAccountId, newN.Get().GetAccountId())
+    }
+}
+

--- a/test/model/model_batch_transaction_test.go
+++ b/test/model/model_batch_transaction_test.go
@@ -1,0 +1,119 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTAccountId = "acc1"
+var exampleBTAmount int32 = 500
+var exampleBTIdentifier = "id1"
+var exampleBTMerchantId int32 = 42
+
+func buildExampleBatchTransaction() *openapiclient.BatchTransaction {
+    b := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    b.SetIdentifier(exampleBTIdentifier)
+    b.SetMerchantid(exampleBTMerchantId)
+    return b
+}
+
+func TestNewBatchTransaction(t *testing.T) {
+    model := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBTAccountId, model.GetAccountId())
+    assert.Equal(t, exampleBTAmount, model.GetAmount())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasMerchantid())
+}
+
+func TestNewBatchTransactionWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+    assert.Equal(t, int32(0), model.GetAmount())
+}
+
+func TestBatchTransactionSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    model.SetIdentifier(exampleBTIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleBTIdentifier, model.GetIdentifier())
+    val, ok := model.GetIdentifierOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTIdentifier, *val)
+    }
+    model.SetMerchantid(exampleBTMerchantId)
+    assert.True(t, model.HasMerchantid())
+    assert.Equal(t, exampleBTMerchantId, model.GetMerchantid())
+    val2, ok2 := model.GetMerchantidOk()
+    require.True(t, ok2)
+    if assert.NotNil(t, val2) {
+        assert.Equal(t, exampleBTMerchantId, *val2)
+    }
+}
+
+func TestBatchTransactionJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransaction()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransaction
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBTAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasIdentifier())
+    assert.Equal(t, exampleBTMerchantId, unmarshalled.GetMerchantid())
+}
+
+func TestBatchTransactionToMap(t *testing.T) {
+    model := buildExampleBatchTransaction()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleBTAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleBTAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, &exampleBTIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableBatchTransactionGetSet(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NullableBatchTransaction{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionUnset(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NewNullableBatchTransaction(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NewNullableBatchTransaction(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransaction
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_bin_lookup_test.go
+++ b/test/model/model_bin_lookup_test.go
@@ -1,0 +1,93 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBinLookup int32 = 123456
+
+func buildExampleBinLookup() *openapiclient.BinLookup {
+    b := openapiclient.NewBinLookup(exampleBinLookup)
+    return b
+}
+
+func TestNewBinLookup(t *testing.T) {
+    model := openapiclient.NewBinLookup(exampleBinLookup)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBinLookup, model.GetBin())
+}
+
+func TestNewBinLookupWithDefaults(t *testing.T) {
+    model := openapiclient.NewBinLookupWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetBin())
+}
+
+func TestBinLookupSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBinLookup(exampleBinLookup)
+    model.SetBin(654321)
+    assert.Equal(t, int32(654321), model.GetBin())
+    val, ok := model.GetBinOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, int32(654321), *val)
+    }
+}
+
+func TestBinLookupJSONRoundTrip(t *testing.T) {
+    model := buildExampleBinLookup()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BinLookup
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBinLookup, unmarshalled.GetBin())
+}
+
+func TestBinLookupToMap(t *testing.T) {
+    model := buildExampleBinLookup()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "bin") {
+        assert.Equal(t, exampleBinLookup, m["bin"])
+    }
+}
+
+func TestNullableBinLookupGetSet(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NullableBinLookup{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBinLookupUnset(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NewNullableBinLookup(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBinLookupJSONRoundTrip(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NewNullableBinLookup(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBinLookup
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBinLookup, newN.Get().GetBin())
+    }
+}
+

--- a/test/model/model_bin_test.go
+++ b/test/model/model_bin_test.go
@@ -1,0 +1,147 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBinCommercial = true
+var exampleBinCorporate = true
+var exampleBinCountry = "GB"
+var exampleBinCredit = true
+var exampleBinCurrency = "GBP"
+var exampleBinDebit = true
+var exampleBinDescription = "Business"
+var exampleBinEu = true
+var exampleBinScheme = "VISA"
+
+func buildExampleBin() *openapiclient.Bin {
+    b := openapiclient.NewBin()
+    b.SetBinCommercial(exampleBinCommercial)
+    b.SetBinCorporate(exampleBinCorporate)
+    b.SetBinCountryIssued(exampleBinCountry)
+    b.SetBinCredit(exampleBinCredit)
+    b.SetBinCurrency(exampleBinCurrency)
+    b.SetBinDebit(exampleBinDebit)
+    b.SetBinDescription(exampleBinDescription)
+    b.SetBinEu(exampleBinEu)
+    b.SetScheme(exampleBinScheme)
+    return b
+}
+
+func TestNewBin(t *testing.T) {
+    model := openapiclient.NewBin()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBinCommercial())
+    assert.False(t, model.HasScheme())
+}
+
+func TestNewBinWithDefaults(t *testing.T) {
+    model := openapiclient.NewBinWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBinDebit())
+}
+
+func TestBinSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBin()
+    model.SetBinCommercial(exampleBinCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleBinCommercial, model.GetBinCommercial())
+    if val, ok := model.GetBinCommercialOk(); assert.True(t, ok) {
+        assert.NotNil(t, val)
+        assert.Equal(t, exampleBinCommercial, *val)
+    }
+
+    model.SetBinCorporate(exampleBinCorporate)
+    assert.True(t, model.HasBinCorporate())
+    assert.Equal(t, exampleBinCorporate, model.GetBinCorporate())
+
+    model.SetBinCountryIssued(exampleBinCountry)
+    assert.True(t, model.HasBinCountryIssued())
+    assert.Equal(t, exampleBinCountry, model.GetBinCountryIssued())
+
+    model.SetBinCredit(exampleBinCredit)
+    assert.True(t, model.HasBinCredit())
+    assert.Equal(t, exampleBinCredit, model.GetBinCredit())
+
+    model.SetBinCurrency(exampleBinCurrency)
+    assert.True(t, model.HasBinCurrency())
+    assert.Equal(t, exampleBinCurrency, model.GetBinCurrency())
+
+    model.SetBinDebit(exampleBinDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleBinDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleBinDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleBinDescription, model.GetBinDescription())
+
+    model.SetBinEu(exampleBinEu)
+    assert.True(t, model.HasBinEu())
+    assert.Equal(t, exampleBinEu, model.GetBinEu())
+
+    model.SetScheme(exampleBinScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleBinScheme, model.GetScheme())
+}
+
+func TestBinJSONRoundTrip(t *testing.T) {
+    model := buildExampleBin()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Bin
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBinCommercial, unmarshalled.GetBinCommercial())
+    assert.Equal(t, exampleBinScheme, unmarshalled.GetScheme())
+}
+
+func TestBinToMap(t *testing.T) {
+    model := buildExampleBin()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "bin_commercial") {
+        assert.Equal(t, &exampleBinCommercial, m["bin_commercial"])
+    }
+    if assert.Contains(t, m, "scheme") {
+        assert.Equal(t, &exampleBinScheme, m["scheme"])
+    }
+}
+
+func TestNullableBinGetSet(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NullableBin{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBinUnset(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NewNullableBin(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBinJSONRoundTrip(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NewNullableBin(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBin
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBinScheme, newN.Get().GetScheme())
+    }
+}
+

--- a/test/model/model_c_res_auth_request_test.go
+++ b/test/model/model_c_res_auth_request_test.go
@@ -1,0 +1,95 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCRes = "cresdata"
+
+func buildExampleCResAuthRequest() *openapiclient.CResAuthRequest {
+    c := openapiclient.NewCResAuthRequest()
+    c.SetCres(exampleCRes)
+    return c
+}
+
+func TestNewCResAuthRequest(t *testing.T) {
+    model := openapiclient.NewCResAuthRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCres())
+}
+
+func TestNewCResAuthRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewCResAuthRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCres())
+}
+
+func TestCResAuthRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCResAuthRequest()
+    model.SetCres(exampleCRes)
+    assert.True(t, model.HasCres())
+    assert.Equal(t, exampleCRes, model.GetCres())
+    val, ok := model.GetCresOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleCRes, *val)
+    }
+}
+
+func TestCResAuthRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleCResAuthRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CResAuthRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCRes, unmarshalled.GetCres())
+}
+
+func TestCResAuthRequestToMap(t *testing.T) {
+    model := buildExampleCResAuthRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "cres") {
+        assert.Equal(t, &exampleCRes, m["cres"])
+    }
+}
+
+func TestNullableCResAuthRequestGetSet(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NullableCResAuthRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCResAuthRequestUnset(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NewNullableCResAuthRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCResAuthRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NewNullableCResAuthRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCResAuthRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCRes, newN.Get().GetCres())
+    }
+}
+

--- a/test/model/model_capture_request_test.go
+++ b/test/model/model_capture_request_test.go
@@ -1,0 +1,119 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCaptureAmount int32 = 5000
+var exampleCaptureIdentifier = "CAPID"
+var exampleCaptureMerchantID int32 = 321
+var exampleCaptureTransno int32 = 42
+
+func buildExampleCaptureRequest() *openapiclient.CaptureRequest {
+    c := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    c.SetAirlineData(*buildExampleAdvice())
+    c.SetAmount(exampleCaptureAmount)
+    c.SetEventManagement(buildExampleEventData())
+    c.SetIdentifier(exampleCaptureIdentifier)
+    c.SetTransno(exampleCaptureTransno)
+    return c
+}
+
+func TestNewCaptureRequest(t *testing.T) {
+    model := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCaptureMerchantID, model.GetMerchantid())
+    assert.False(t, model.HasAmount())
+}
+
+func TestNewCaptureRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewCaptureRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestCaptureRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    model.SetAirlineData(*buildExampleAdvice())
+    assert.True(t, model.HasAirlineData())
+
+    model.SetAmount(exampleCaptureAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleCaptureAmount, model.GetAmount())
+
+    model.SetEventManagement(buildExampleEventData())
+    assert.True(t, model.HasEventManagement())
+
+    model.SetIdentifier(exampleCaptureIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleCaptureIdentifier, model.GetIdentifier())
+
+    model.SetMerchantid(exampleCaptureMerchantID)
+    assert.Equal(t, exampleCaptureMerchantID, model.GetMerchantid())
+
+    model.SetTransno(exampleCaptureTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleCaptureTransno, model.GetTransno())
+}
+
+func TestCaptureRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleCaptureRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CaptureRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCaptureMerchantID, unmarshalled.GetMerchantid())
+    assert.True(t, unmarshalled.HasIdentifier())
+}
+
+func TestCaptureRequestToMap(t *testing.T) {
+    model := buildExampleCaptureRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "merchantid") {
+        assert.Equal(t, exampleCaptureMerchantID, m["merchantid"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, &exampleCaptureIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableCaptureRequestGetSet(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NullableCaptureRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCaptureRequestUnset(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NewNullableCaptureRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCaptureRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NewNullableCaptureRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCaptureRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCaptureIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_card_holder_account_test.go
+++ b/test/model/model_card_holder_account_test.go
@@ -1,0 +1,138 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCHAAccountId = "acc123"
+var exampleCHADateCreated = time.Date(2023, time.February, 1, 9, 0, 0, 0, time.UTC)
+var exampleCHADefaultCardId = "cardA"
+var exampleCHADefaultCardIndex int32 = 0
+var exampleCHALastModified = time.Date(2023, time.March, 1, 10, 0, 0, 0, time.UTC)
+var exampleCHAStatus = "ACTIVE"
+var exampleCHAUniqueId = "unique1"
+
+func buildExampleCardHolderAccount() *openapiclient.CardHolderAccount {
+    c := openapiclient.NewCardHolderAccount(exampleCHAAccountId, buildExampleContact())
+    c.SetCards([]openapiclient.Card{*buildExampleCard()})
+    c.SetDateCreated(exampleCHADateCreated)
+    c.SetDefaultCardId(exampleCHADefaultCardId)
+    c.SetDefaultCardIndex(exampleCHADefaultCardIndex)
+    c.SetLastModified(exampleCHALastModified)
+    c.SetStatus(exampleCHAStatus)
+    c.SetUniqueId(exampleCHAUniqueId)
+    return c
+}
+
+func TestNewCardHolderAccount(t *testing.T) {
+    contact := buildExampleContact()
+    model := openapiclient.NewCardHolderAccount(exampleCHAAccountId, contact)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCHAAccountId, model.GetAccountId())
+    assert.Equal(t, contact, model.GetContact())
+    assert.False(t, model.HasCards())
+}
+
+func TestNewCardHolderAccountWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardHolderAccountWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+}
+
+func TestCardHolderAccountSetGetCycle(t *testing.T) {
+    contact := buildExampleContact()
+    model := openapiclient.NewCardHolderAccount(exampleCHAAccountId, contact)
+    model.SetCards([]openapiclient.Card{*buildExampleCard()})
+    assert.True(t, model.HasCards())
+    assert.Equal(t, 1, len(model.GetCards()))
+
+    model.SetContact(contact)
+    assert.Equal(t, contact, model.GetContact())
+
+    model.SetDateCreated(exampleCHADateCreated)
+    assert.True(t, model.HasDateCreated())
+    assert.Equal(t, exampleCHADateCreated, model.GetDateCreated())
+
+    model.SetDefaultCardId(exampleCHADefaultCardId)
+    assert.True(t, model.HasDefaultCardId())
+    assert.Equal(t, exampleCHADefaultCardId, model.GetDefaultCardId())
+
+    model.SetDefaultCardIndex(exampleCHADefaultCardIndex)
+    assert.True(t, model.HasDefaultCardIndex())
+    assert.Equal(t, exampleCHADefaultCardIndex, model.GetDefaultCardIndex())
+
+    model.SetLastModified(exampleCHALastModified)
+    assert.True(t, model.HasLastModified())
+    assert.Equal(t, exampleCHALastModified, model.GetLastModified())
+
+    model.SetStatus(exampleCHAStatus)
+    assert.True(t, model.HasStatus())
+    assert.Equal(t, exampleCHAStatus, model.GetStatus())
+
+    model.SetUniqueId(exampleCHAUniqueId)
+    assert.True(t, model.HasUniqueId())
+    assert.Equal(t, exampleCHAUniqueId, model.GetUniqueId())
+}
+
+func TestCardHolderAccountJSONRoundTrip(t *testing.T) {
+    model := buildExampleCardHolderAccount()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CardHolderAccount
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCHAAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasStatus())
+}
+
+func TestCardHolderAccountToMap(t *testing.T) {
+    model := buildExampleCardHolderAccount()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleCHAAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "default_card_id") {
+        assert.Equal(t, &exampleCHADefaultCardId, m["default_card_id"])
+    }
+}
+
+func TestNullableCardHolderAccountGetSet(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NullableCardHolderAccount{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardHolderAccountUnset(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NewNullableCardHolderAccount(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardHolderAccountJSONRoundTrip(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NewNullableCardHolderAccount(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCardHolderAccount
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCHAUniqueId, newN.Get().GetUniqueId())
+    }
+}
+

--- a/test/model/model_card_status_test.go
+++ b/test/model/model_card_status_test.go
@@ -1,0 +1,101 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCardStatusValue = "ACTIVE"
+var exampleCardStatusDefault = true
+
+func buildExampleCardStatus() *openapiclient.CardStatus {
+    c := openapiclient.NewCardStatus()
+    c.SetCardStatus(exampleCardStatusValue)
+    c.SetDefault(exampleCardStatusDefault)
+    return c
+}
+
+func TestNewCardStatus(t *testing.T) {
+    model := openapiclient.NewCardStatus()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+    assert.False(t, model.HasDefault())
+}
+
+func TestNewCardStatusWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardStatusWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+}
+
+func TestCardStatusSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCardStatus()
+    model.SetCardStatus(exampleCardStatusValue)
+    assert.True(t, model.HasCardStatus())
+    assert.Equal(t, exampleCardStatusValue, model.GetCardStatus())
+
+    model.SetDefault(exampleCardStatusDefault)
+    assert.True(t, model.HasDefault())
+    assert.Equal(t, exampleCardStatusDefault, model.GetDefault())
+}
+
+func TestCardStatusJSONRoundTrip(t *testing.T) {
+    model := buildExampleCardStatus()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CardStatus
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCardStatusValue, unmarshalled.GetCardStatus())
+    assert.True(t, unmarshalled.GetDefault())
+}
+
+func TestCardStatusToMap(t *testing.T) {
+    model := buildExampleCardStatus()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "card_status") {
+        assert.Equal(t, &exampleCardStatusValue, m["card_status"])
+    }
+    if assert.Contains(t, m, "default") {
+        assert.Equal(t, &exampleCardStatusDefault, m["default"])
+    }
+}
+
+func TestNullableCardStatusGetSet(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NullableCardStatus{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardStatusUnset(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NewNullableCardStatus(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardStatusJSONRoundTrip(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NewNullableCardStatus(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCardStatus
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCardStatusValue, newN.Get().GetCardStatus())
+    }
+}
+

--- a/test/model/model_card_test.go
+++ b/test/model/model_card_test.go
@@ -1,0 +1,209 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCardCommercial = true
+var exampleCardCorporate = true
+var exampleCardCountry = "US"
+var exampleCardCredit = true
+var exampleCardCurrency = "USD"
+var exampleCardDebit = true
+var exampleCardDescription = "Gold"
+var exampleCardEu = false
+var exampleCardId = "card1"
+var exampleCardStatus = "ACTIVE"
+var exampleCardDate = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+var exampleCardDefault = true
+var exampleCardExpMonth int32 = 12
+var exampleCardExpYear int32 = 30
+var exampleCardLabel = "Main"
+var exampleCardLabel2 = "Main 12/30"
+var exampleCardLast4 = "1234"
+var exampleCardName = "John Smith"
+var exampleCardScheme = "VISA"
+var exampleCardToken = "tok123"
+
+func buildExampleCard() *openapiclient.Card {
+    c := openapiclient.NewCard()
+    c.SetBinCommercial(exampleCardCommercial)
+    c.SetBinCorporate(exampleCardCorporate)
+    c.SetBinCountryIssued(exampleCardCountry)
+    c.SetBinCredit(exampleCardCredit)
+    c.SetBinCurrency(exampleCardCurrency)
+    c.SetBinDebit(exampleCardDebit)
+    c.SetBinDescription(exampleCardDescription)
+    c.SetBinEu(exampleCardEu)
+    c.SetCardId(exampleCardId)
+    c.SetCardStatus(exampleCardStatus)
+    c.SetDateCreated(exampleCardDate)
+    c.SetDefault(exampleCardDefault)
+    c.SetExpmonth(exampleCardExpMonth)
+    c.SetExpyear(exampleCardExpYear)
+    c.SetLabel(exampleCardLabel)
+    c.SetLabel2(exampleCardLabel2)
+    c.SetLast4digits(exampleCardLast4)
+    c.SetNameOnCard(exampleCardName)
+    c.SetScheme(exampleCardScheme)
+    c.SetToken(exampleCardToken)
+    return c
+}
+
+func TestNewCard(t *testing.T) {
+    model := openapiclient.NewCard()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardId())
+}
+
+func TestNewCardWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+}
+
+func TestCardSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCard()
+    model.SetBinCommercial(exampleCardCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleCardCommercial, model.GetBinCommercial())
+
+    model.SetBinCorporate(exampleCardCorporate)
+    assert.True(t, model.HasBinCorporate())
+    assert.Equal(t, exampleCardCorporate, model.GetBinCorporate())
+
+    model.SetBinCountryIssued(exampleCardCountry)
+    assert.True(t, model.HasBinCountryIssued())
+    assert.Equal(t, exampleCardCountry, model.GetBinCountryIssued())
+
+    model.SetBinCredit(exampleCardCredit)
+    assert.True(t, model.HasBinCredit())
+    assert.Equal(t, exampleCardCredit, model.GetBinCredit())
+
+    model.SetBinCurrency(exampleCardCurrency)
+    assert.True(t, model.HasBinCurrency())
+    assert.Equal(t, exampleCardCurrency, model.GetBinCurrency())
+
+    model.SetBinDebit(exampleCardDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleCardDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleCardDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleCardDescription, model.GetBinDescription())
+
+    model.SetBinEu(exampleCardEu)
+    assert.True(t, model.HasBinEu())
+    assert.Equal(t, exampleCardEu, model.GetBinEu())
+
+    model.SetCardId(exampleCardId)
+    assert.True(t, model.HasCardId())
+    assert.Equal(t, exampleCardId, model.GetCardId())
+
+    model.SetCardStatus(exampleCardStatus)
+    assert.True(t, model.HasCardStatus())
+    assert.Equal(t, exampleCardStatus, model.GetCardStatus())
+
+    model.SetDateCreated(exampleCardDate)
+    assert.True(t, model.HasDateCreated())
+    assert.Equal(t, exampleCardDate, model.GetDateCreated())
+
+    model.SetDefault(exampleCardDefault)
+    assert.True(t, model.HasDefault())
+    assert.Equal(t, exampleCardDefault, model.GetDefault())
+
+    model.SetExpmonth(exampleCardExpMonth)
+    assert.True(t, model.HasExpmonth())
+    assert.Equal(t, exampleCardExpMonth, model.GetExpmonth())
+
+    model.SetExpyear(exampleCardExpYear)
+    assert.True(t, model.HasExpyear())
+    assert.Equal(t, exampleCardExpYear, model.GetExpyear())
+
+    model.SetLabel(exampleCardLabel)
+    assert.True(t, model.HasLabel())
+    assert.Equal(t, exampleCardLabel, model.GetLabel())
+
+    model.SetLabel2(exampleCardLabel2)
+    assert.True(t, model.HasLabel2())
+    assert.Equal(t, exampleCardLabel2, model.GetLabel2())
+
+    model.SetLast4digits(exampleCardLast4)
+    assert.True(t, model.HasLast4digits())
+    assert.Equal(t, exampleCardLast4, model.GetLast4digits())
+
+    model.SetNameOnCard(exampleCardName)
+    assert.True(t, model.HasNameOnCard())
+    assert.Equal(t, exampleCardName, model.GetNameOnCard())
+
+    model.SetScheme(exampleCardScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleCardScheme, model.GetScheme())
+
+    model.SetToken(exampleCardToken)
+    assert.True(t, model.HasToken())
+    assert.Equal(t, exampleCardToken, model.GetToken())
+}
+
+func TestCardJSONRoundTrip(t *testing.T) {
+    model := buildExampleCard()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Card
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCardId, unmarshalled.GetCardId())
+    assert.Equal(t, exampleCardScheme, unmarshalled.GetScheme())
+}
+
+func TestCardToMap(t *testing.T) {
+    model := buildExampleCard()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "card_id") {
+        assert.Equal(t, &exampleCardId, m["card_id"])
+    }
+    if assert.Contains(t, m, "scheme") {
+        assert.Equal(t, &exampleCardScheme, m["scheme"])
+    }
+}
+
+func TestNullableCardGetSet(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NullableCard{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardUnset(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NewNullableCard(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardJSONRoundTrip(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NewNullableCard(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCard
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCardId, newN.Get().GetCardId())
+    }
+}
+

--- a/test/model/model_charge_request_test.go
+++ b/test/model/model_charge_request_test.go
@@ -1,0 +1,166 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleChargeAmount int32 = 1000
+var exampleChargeAvsPolicy = "1"
+var exampleChargeAgreement = "agr"
+var exampleChargeCsc = "123"
+var exampleChargeCscPolicy = "2"
+var exampleChargeCurrency = "GBP"
+var exampleChargeDuplicate = "1"
+var exampleChargeIdentifier = "ID123"
+var exampleChargeInitiation = "M"
+var exampleChargeMatchAvsa = "Y"
+var exampleChargeMerchantID int32 = 55
+var exampleChargeTag = []string{"t1", "t2"}
+var exampleChargeToken = "tok"
+var exampleChargeTransInfo = "info"
+var exampleChargeTransType = "SALE"
+
+func buildExampleChargeRequest() *openapiclient.ChargeRequest {
+    c := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    c.SetAvsPostcodePolicy(exampleChargeAvsPolicy)
+    c.SetCardholderAgreement(exampleChargeAgreement)
+    c.SetCsc(exampleChargeCsc)
+    c.SetCscPolicy(exampleChargeCscPolicy)
+    c.SetCurrency(exampleChargeCurrency)
+    c.SetDuplicatePolicy(exampleChargeDuplicate)
+    c.SetInitiation(exampleChargeInitiation)
+    c.SetMatchAvsa(exampleChargeMatchAvsa)
+    c.SetTag(exampleChargeTag)
+    c.SetThreedsecure(buildExampleThreeDSecure())
+    c.SetTransInfo(exampleChargeTransInfo)
+    c.SetTransType(exampleChargeTransType)
+    return c
+}
+
+func TestNewChargeRequest(t *testing.T) {
+    model := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleChargeAmount, model.GetAmount())
+    assert.Equal(t, exampleChargeIdentifier, model.GetIdentifier())
+    assert.Equal(t, exampleChargeMerchantID, model.GetMerchantid())
+    assert.Equal(t, exampleChargeToken, model.GetToken())
+    assert.False(t, model.HasAvsPostcodePolicy())
+}
+
+func TestNewChargeRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewChargeRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+}
+
+func TestChargeRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    model.SetAvsPostcodePolicy(exampleChargeAvsPolicy)
+    assert.True(t, model.HasAvsPostcodePolicy())
+    assert.Equal(t, exampleChargeAvsPolicy, model.GetAvsPostcodePolicy())
+
+    model.SetCardholderAgreement(exampleChargeAgreement)
+    assert.True(t, model.HasCardholderAgreement())
+    assert.Equal(t, exampleChargeAgreement, model.GetCardholderAgreement())
+
+    model.SetCsc(exampleChargeCsc)
+    assert.True(t, model.HasCsc())
+    assert.Equal(t, exampleChargeCsc, model.GetCsc())
+
+    model.SetCscPolicy(exampleChargeCscPolicy)
+    assert.True(t, model.HasCscPolicy())
+    assert.Equal(t, exampleChargeCscPolicy, model.GetCscPolicy())
+
+    model.SetCurrency(exampleChargeCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleChargeCurrency, model.GetCurrency())
+
+    model.SetDuplicatePolicy(exampleChargeDuplicate)
+    assert.True(t, model.HasDuplicatePolicy())
+    assert.Equal(t, exampleChargeDuplicate, model.GetDuplicatePolicy())
+
+    model.SetInitiation(exampleChargeInitiation)
+    assert.True(t, model.HasInitiation())
+    assert.Equal(t, exampleChargeInitiation, model.GetInitiation())
+
+    model.SetMatchAvsa(exampleChargeMatchAvsa)
+    assert.True(t, model.HasMatchAvsa())
+    assert.Equal(t, exampleChargeMatchAvsa, model.GetMatchAvsa())
+
+    model.SetTag(exampleChargeTag)
+    assert.True(t, model.HasTag())
+    assert.Equal(t, exampleChargeTag, model.GetTag())
+
+    model.SetThreedsecure(buildExampleThreeDSecure())
+    assert.True(t, model.HasThreedsecure())
+
+    model.SetTransInfo(exampleChargeTransInfo)
+    assert.True(t, model.HasTransInfo())
+    assert.Equal(t, exampleChargeTransInfo, model.GetTransInfo())
+
+    model.SetTransType(exampleChargeTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleChargeTransType, model.GetTransType())
+}
+
+func TestChargeRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleChargeRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.ChargeRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleChargeToken, unmarshalled.GetToken())
+    assert.True(t, unmarshalled.HasTransType())
+}
+
+func TestChargeRequestToMap(t *testing.T) {
+    model := buildExampleChargeRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleChargeAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, exampleChargeIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableChargeRequestGetSet(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NullableChargeRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableChargeRequestUnset(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NewNullableChargeRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableChargeRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NewNullableChargeRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableChargeRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleChargeIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_check_batch_status_response_test.go
+++ b/test/model/model_check_batch_status_response_test.go
@@ -1,0 +1,89 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func buildExampleCheckBatchStatusResponse() *openapiclient.CheckBatchStatusResponse {
+    c := openapiclient.NewCheckBatchStatusResponse()
+    c.SetBatches([]openapiclient.Batch{*buildExampleBatch()})
+    return c
+}
+
+func TestNewCheckBatchStatusResponse(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponse()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBatches())
+}
+
+func TestNewCheckBatchStatusResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBatches())
+}
+
+func TestCheckBatchStatusResponseSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponse()
+    model.SetBatches([]openapiclient.Batch{*buildExampleBatch()})
+    assert.True(t, model.HasBatches())
+    assert.Equal(t, 1, len(model.GetBatches()))
+}
+
+func TestCheckBatchStatusResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleCheckBatchStatusResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CheckBatchStatusResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasBatches())
+    assert.Equal(t, 1, len(unmarshalled.GetBatches()))
+}
+
+func TestCheckBatchStatusResponseToMap(t *testing.T) {
+    model := buildExampleCheckBatchStatusResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batches") {
+        assert.NotNil(t, m["batches"])
+    }
+}
+
+func TestNullableCheckBatchStatusResponseGetSet(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NullableCheckBatchStatusResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCheckBatchStatusResponseUnset(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NewNullableCheckBatchStatusResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCheckBatchStatusResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NewNullableCheckBatchStatusResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCheckBatchStatusResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, 1, len(newN.Get().GetBatches()))
+    }
+}
+

--- a/test/model/model_check_batch_status_test.go
+++ b/test/model/model_check_batch_status_test.go
@@ -1,0 +1,101 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCBSBatchIds = []int32{1, 2}
+var exampleCBSClientAccount = "client1"
+
+func buildExampleCheckBatchStatus() *openapiclient.CheckBatchStatus {
+    c := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    c.SetClientAccountId(exampleCBSClientAccount)
+    return c
+}
+
+func TestNewCheckBatchStatus(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCBSBatchIds, model.GetBatchId())
+    assert.False(t, model.HasClientAccountId())
+}
+
+func TestNewCheckBatchStatusWithDefaults(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusWithDefaults()
+    require.NotNil(t, model)
+    assert.Len(t, model.GetBatchId(), 0)
+}
+
+func TestCheckBatchStatusSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    model.SetClientAccountId(exampleCBSClientAccount)
+    assert.True(t, model.HasClientAccountId())
+    assert.Equal(t, exampleCBSClientAccount, model.GetClientAccountId())
+    val, ok := model.GetClientAccountIdOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleCBSClientAccount, *val)
+    }
+}
+
+func TestCheckBatchStatusJSONRoundTrip(t *testing.T) {
+    model := buildExampleCheckBatchStatus()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CheckBatchStatus
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCBSClientAccount, unmarshalled.GetClientAccountId())
+    assert.Equal(t, exampleCBSBatchIds, unmarshalled.GetBatchId())
+}
+
+func TestCheckBatchStatusToMap(t *testing.T) {
+    model := buildExampleCheckBatchStatus()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_id") {
+        assert.Equal(t, exampleCBSBatchIds, m["batch_id"])
+    }
+    if assert.Contains(t, m, "client_account_id") {
+        assert.Equal(t, &exampleCBSClientAccount, m["client_account_id"])
+    }
+}
+
+func TestNullableCheckBatchStatusGetSet(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NullableCheckBatchStatus{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCheckBatchStatusUnset(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NewNullableCheckBatchStatus(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCheckBatchStatusJSONRoundTrip(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NewNullableCheckBatchStatus(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCheckBatchStatus
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCBSClientAccount, newN.Get().GetClientAccountId())
+    }
+}
+

--- a/test/model/model_contact_details_test.go
+++ b/test/model/model_contact_details_test.go
@@ -1,0 +1,170 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAddress1 = "1 Test Way"
+var exampleAddress2 = "Suite 5"
+var exampleAddress3 = "Floor 3"
+var exampleArea = "Test City"
+var exampleCompany = "Test Co"
+var exampleCountry = "GB"
+var exampleEmail = "contact@example.com"
+var exampleFirstname = "Jane"
+var exampleLastname = "Doe"
+var exampleMobile = "07123456789"
+var examplePostcode = "TE5 7ST"
+var exampleTelephone = "01111111111"
+var exampleTitle = "Ms"
+
+func buildExampleContactDetails() *openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1(exampleAddress1)
+	c.SetAddress2(exampleAddress2)
+	c.SetAddress3(exampleAddress3)
+	c.SetArea(exampleArea)
+	c.SetCompany(exampleCompany)
+	c.SetCountry(exampleCountry)
+	c.SetEmail(exampleEmail)
+	c.SetFirstname(exampleFirstname)
+	c.SetLastname(exampleLastname)
+	c.SetMobileNo(exampleMobile)
+	c.SetPostcode(examplePostcode)
+	c.SetTelephoneNo(exampleTelephone)
+	c.SetTitle(exampleTitle)
+	return c
+}
+
+func TestNewContactDetails(t *testing.T) {
+	model := openapiclient.NewContactDetails()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.False(t, model.HasCountry())
+}
+
+func TestNewContactDetailsWithDefaults(t *testing.T) {
+	model := openapiclient.NewContactDetailsWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.Equal(t, "", model.GetAddress1())
+}
+
+func TestContactDetailsSetGetCycle(t *testing.T) {
+	model := openapiclient.NewContactDetails()
+	model.SetAddress1(exampleAddress1)
+	assert.True(t, model.HasAddress1())
+	assert.Equal(t, exampleAddress1, model.GetAddress1())
+	if val, ok := model.GetAddress1Ok(); assert.True(t, ok) {
+		assert.Equal(t, exampleAddress1, *val)
+	}
+
+	model.SetAddress2(exampleAddress2)
+	assert.True(t, model.HasAddress2())
+	assert.Equal(t, exampleAddress2, model.GetAddress2())
+
+	model.SetAddress3(exampleAddress3)
+	assert.True(t, model.HasAddress3())
+	assert.Equal(t, exampleAddress3, model.GetAddress3())
+
+	model.SetArea(exampleArea)
+	assert.True(t, model.HasArea())
+	assert.Equal(t, exampleArea, model.GetArea())
+
+	model.SetCompany(exampleCompany)
+	assert.True(t, model.HasCompany())
+	assert.Equal(t, exampleCompany, model.GetCompany())
+
+	model.SetCountry(exampleCountry)
+	assert.True(t, model.HasCountry())
+	assert.Equal(t, exampleCountry, model.GetCountry())
+
+	model.SetEmail(exampleEmail)
+	assert.True(t, model.HasEmail())
+	assert.Equal(t, exampleEmail, model.GetEmail())
+
+	model.SetFirstname(exampleFirstname)
+	assert.True(t, model.HasFirstname())
+	assert.Equal(t, exampleFirstname, model.GetFirstname())
+
+	model.SetLastname(exampleLastname)
+	assert.True(t, model.HasLastname())
+	assert.Equal(t, exampleLastname, model.GetLastname())
+
+	model.SetMobileNo(exampleMobile)
+	assert.True(t, model.HasMobileNo())
+	assert.Equal(t, exampleMobile, model.GetMobileNo())
+
+	model.SetPostcode(examplePostcode)
+	assert.True(t, model.HasPostcode())
+	assert.Equal(t, examplePostcode, model.GetPostcode())
+
+	model.SetTelephoneNo(exampleTelephone)
+	assert.True(t, model.HasTelephoneNo())
+	assert.Equal(t, exampleTelephone, model.GetTelephoneNo())
+
+	model.SetTitle(exampleTitle)
+	assert.True(t, model.HasTitle())
+	assert.Equal(t, exampleTitle, model.GetTitle())
+}
+
+func TestContactDetailsJSONRoundTrip(t *testing.T) {
+	model := buildExampleContactDetails()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ContactDetails
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAddress1, unmarshalled.GetAddress1())
+	assert.Equal(t, exampleCountry, unmarshalled.GetCountry())
+	assert.Equal(t, exampleEmail, unmarshalled.GetEmail())
+}
+
+func TestContactDetailsToMap(t *testing.T) {
+	model := buildExampleContactDetails()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "address1") {
+		assert.Equal(t, &exampleAddress1, m["address1"])
+	}
+	if assert.Contains(t, m, "country") {
+		assert.Equal(t, &exampleCountry, m["country"])
+	}
+}
+
+func TestNullableContactDetailsGetSet(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NullableContactDetails{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableContactDetailsUnset(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NewNullableContactDetails(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableContactDetailsJSONRoundTrip(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NewNullableContactDetails(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableContactDetails
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleEmail, newN.Get().GetEmail())
+	}
+}

--- a/test/model/model_decision_test.go
+++ b/test/model/model_decision_test.go
@@ -1,0 +1,130 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAcsURL = "https://acs.example.com"
+var exampleCreq = "creqdata"
+var exampleMerchantID int32 = 100
+var exampleThreeDSID = "threedid"
+var exampleTransno int32 = 5
+var exampleAuthMerchant int32 = 321
+var exampleAuthResult int32 = 1
+var exampleAuthCode = "A"
+var exampleAuthMsg = "Approved"
+
+func buildExampleRequestChallenged() openapiclient.RequestChallenged {
+	r := openapiclient.NewRequestChallenged()
+	r.SetAcsUrl(exampleAcsURL)
+	r.SetCreq(exampleCreq)
+	r.SetMerchantid(exampleMerchantID)
+	r.SetThreedserverTransId(exampleThreeDSID)
+	r.SetTransno(exampleTransno)
+	return *r
+}
+
+func buildExampleAuthResp() openapiclient.AuthResponse {
+	a := openapiclient.NewAuthResponse(exampleAuthMerchant, exampleAuthResult, exampleAuthCode, exampleAuthMsg)
+	a.SetAuthcode("CODE")
+	return *a
+}
+
+func buildExampleDecision() *openapiclient.Decision {
+	d := openapiclient.NewDecision()
+	d.SetAuthResponse(buildExampleAuthResp())
+	d.SetRequestChallenged(buildExampleRequestChallenged())
+	return d
+}
+
+func TestNewDecision(t *testing.T) {
+	model := openapiclient.NewDecision()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthResponse())
+	assert.False(t, model.HasRequestChallenged())
+}
+
+func TestNewDecisionWithDefaults(t *testing.T) {
+	model := openapiclient.NewDecisionWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthResponse())
+}
+
+func TestDecisionSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDecision()
+	ar := buildExampleAuthResp()
+	model.SetAuthResponse(ar)
+	assert.True(t, model.HasAuthResponse())
+	assert.Equal(t, ar, model.GetAuthResponse())
+	if val, ok := model.GetAuthResponseOk(); assert.True(t, ok) {
+		assert.Equal(t, ar, *val)
+	}
+
+	rc := buildExampleRequestChallenged()
+	model.SetRequestChallenged(rc)
+	assert.True(t, model.HasRequestChallenged())
+	assert.Equal(t, rc, model.GetRequestChallenged())
+	if val, ok := model.GetRequestChallengedOk(); assert.True(t, ok) {
+		assert.Equal(t, rc, *val)
+	}
+}
+
+func TestDecisionJSONRoundTrip(t *testing.T) {
+	model := buildExampleDecision()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Decision
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasAuthResponse())
+	assert.True(t, unmarshalled.HasRequestChallenged())
+}
+
+func TestDecisionToMap(t *testing.T) {
+	model := buildExampleDecision()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "AuthResponse") {
+		assert.NotNil(t, m["AuthResponse"])
+	}
+	if assert.Contains(t, m, "RequestChallenged") {
+		assert.NotNil(t, m["RequestChallenged"])
+	}
+}
+
+func TestNullableDecisionGetSet(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NullableDecision{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDecisionUnset(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NewNullableDecision(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDecisionJSONRoundTrip(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NewNullableDecision(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDecision
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.True(t, newN.Get().HasRequestChallenged())
+	}
+}

--- a/test/model/model_direct_post_request_test.go
+++ b/test/model/model_direct_post_request_test.go
@@ -1,0 +1,208 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDPAmount int32 = 9999
+var exampleDPAvsPolicy = "1"
+var exampleDPCard = "4111111111111111"
+var exampleDPCsc = "123"
+var exampleDPCscPolicy = "2"
+var exampleDPCurrency = "GBP"
+var exampleDPDupPolicy = "1"
+var exampleDPExpMonth int32 = 10
+var exampleDPExpYear int32 = 2026
+var exampleDPIdentifier = "id123"
+var exampleDPMac = "MAC"
+var exampleDPMatchAvsa = "0"
+var exampleDPName = "John Doe"
+var exampleDPNonce = "ABCDEF"
+var exampleDPRedirectFail = "https://fail"
+var exampleDPRedirectSuccess = "https://ok"
+var exampleDPTag = []string{"one", "two"}
+var exampleDPTransInfo = "info"
+var exampleDPTransType = "SALE"
+
+func buildExampleContact() openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1("addr")
+	c.SetEmail("c@example.com")
+	return *c
+}
+
+func buildExampleThreeDS() openapiclient.ThreeDSecure {
+	t := openapiclient.NewThreeDSecure()
+	t.SetAcceptHeaders("text/html")
+	return *t
+}
+
+func buildExampleDirectPostRequest() *openapiclient.DirectPostRequest {
+	d := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	d.SetAvsPostcodePolicy(exampleDPAvsPolicy)
+	d.SetBillTo(buildExampleContact())
+	d.SetCsc(exampleDPCsc)
+	d.SetCscPolicy(exampleDPCscPolicy)
+	d.SetCurrency(exampleDPCurrency)
+	d.SetDuplicatePolicy(exampleDPDupPolicy)
+	d.SetMatchAvsa(exampleDPMatchAvsa)
+	d.SetNameOnCard(exampleDPName)
+	d.SetNonce(exampleDPNonce)
+	d.SetRedirectFailure(exampleDPRedirectFail)
+	d.SetRedirectSuccess(exampleDPRedirectSuccess)
+	d.SetShipTo(buildExampleContact())
+	d.SetTag(exampleDPTag)
+	d.SetThreedsecure(buildExampleThreeDS())
+	d.SetTransInfo(exampleDPTransInfo)
+	d.SetTransType(exampleDPTransType)
+	return d
+}
+
+func TestNewDirectPostRequest(t *testing.T) {
+	model := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDPAmount, model.GetAmount())
+	assert.Equal(t, exampleDPCard, model.GetCardnumber())
+	assert.False(t, model.HasCsc())
+}
+
+func TestNewDirectPostRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDirectPostRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+	assert.Equal(t, "", model.GetCardnumber())
+}
+
+func TestDirectPostRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	model.SetAvsPostcodePolicy(exampleDPAvsPolicy)
+	assert.True(t, model.HasAvsPostcodePolicy())
+	assert.Equal(t, exampleDPAvsPolicy, model.GetAvsPostcodePolicy())
+
+	ct := buildExampleContact()
+	model.SetBillTo(ct)
+	assert.True(t, model.HasBillTo())
+	assert.Equal(t, ct, model.GetBillTo())
+
+	model.SetCsc(exampleDPCsc)
+	assert.True(t, model.HasCsc())
+	assert.Equal(t, exampleDPCsc, model.GetCsc())
+
+	model.SetCscPolicy(exampleDPCscPolicy)
+	assert.True(t, model.HasCscPolicy())
+	assert.Equal(t, exampleDPCscPolicy, model.GetCscPolicy())
+
+	model.SetCurrency(exampleDPCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleDPCurrency, model.GetCurrency())
+
+	model.SetDuplicatePolicy(exampleDPDupPolicy)
+	assert.True(t, model.HasDuplicatePolicy())
+	assert.Equal(t, exampleDPDupPolicy, model.GetDuplicatePolicy())
+
+	model.SetMatchAvsa(exampleDPMatchAvsa)
+	assert.True(t, model.HasMatchAvsa())
+	assert.Equal(t, exampleDPMatchAvsa, model.GetMatchAvsa())
+
+	model.SetNameOnCard(exampleDPName)
+	assert.True(t, model.HasNameOnCard())
+	assert.Equal(t, exampleDPName, model.GetNameOnCard())
+
+	model.SetNonce(exampleDPNonce)
+	assert.True(t, model.HasNonce())
+	assert.Equal(t, exampleDPNonce, model.GetNonce())
+
+	model.SetRedirectFailure(exampleDPRedirectFail)
+	assert.True(t, model.HasRedirectFailure())
+	assert.Equal(t, exampleDPRedirectFail, model.GetRedirectFailure())
+
+	model.SetRedirectSuccess(exampleDPRedirectSuccess)
+	assert.True(t, model.HasRedirectSuccess())
+	assert.Equal(t, exampleDPRedirectSuccess, model.GetRedirectSuccess())
+
+	ship := buildExampleContact()
+	model.SetShipTo(ship)
+	assert.True(t, model.HasShipTo())
+	assert.Equal(t, ship, model.GetShipTo())
+
+	model.SetTag(exampleDPTag)
+	assert.True(t, model.HasTag())
+	assert.Equal(t, exampleDPTag, model.GetTag())
+
+	td := buildExampleThreeDS()
+	model.SetThreedsecure(td)
+	assert.True(t, model.HasThreedsecure())
+	assert.Equal(t, td, model.GetThreedsecure())
+
+	model.SetTransInfo(exampleDPTransInfo)
+	assert.True(t, model.HasTransInfo())
+	assert.Equal(t, exampleDPTransInfo, model.GetTransInfo())
+
+	model.SetTransType(exampleDPTransType)
+	assert.True(t, model.HasTransType())
+	assert.Equal(t, exampleDPTransType, model.GetTransType())
+}
+
+func TestDirectPostRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDirectPostRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DirectPostRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleDPAmount, unmarshalled.GetAmount())
+	assert.True(t, unmarshalled.HasCsc())
+	assert.True(t, unmarshalled.HasThreedsecure())
+}
+
+func TestDirectPostRequestToMap(t *testing.T) {
+	model := buildExampleDirectPostRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "amount") {
+		assert.Equal(t, exampleDPAmount, m["amount"])
+	}
+	if assert.Contains(t, m, "avs_postcode_policy") {
+		assert.Equal(t, &exampleDPAvsPolicy, m["avs_postcode_policy"])
+	}
+	if assert.Contains(t, m, "tag") {
+		assert.Equal(t, exampleDPTag, m["tag"])
+	}
+}
+
+func TestNullableDirectPostRequestGetSet(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NullableDirectPostRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDirectPostRequestUnset(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NewNullableDirectPostRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDirectPostRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NewNullableDirectPostRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDirectPostRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleDPIdentifier, newN.Get().GetIdentifier())
+	}
+}

--- a/test/model/model_direct_token_auth_request_test.go
+++ b/test/model/model_direct_token_auth_request_test.go
@@ -1,0 +1,107 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleNonce = "ABC"
+var exampleRedirectFail = "https://fail"
+var exampleRedirectSuccess = "https://ok"
+var exampleToken = "tok123"
+
+func buildExampleDirectTokenAuthRequest() *openapiclient.DirectTokenAuthRequest {
+	d := openapiclient.NewDirectTokenAuthRequest()
+	d.SetNonce(exampleNonce)
+	d.SetRedirectFailure(exampleRedirectFail)
+	d.SetRedirectSuccess(exampleRedirectSuccess)
+	d.SetToken(exampleToken)
+	return d
+}
+
+func TestNewDirectTokenAuthRequest(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequest()
+	require.NotNil(t, model)
+	assert.False(t, model.HasToken())
+}
+
+func TestNewDirectTokenAuthRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasToken())
+}
+
+func TestDirectTokenAuthRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequest()
+	model.SetNonce(exampleNonce)
+	assert.True(t, model.HasNonce())
+	assert.Equal(t, exampleNonce, model.GetNonce())
+
+	model.SetRedirectFailure(exampleRedirectFail)
+	assert.True(t, model.HasRedirectFailure())
+	assert.Equal(t, exampleRedirectFail, model.GetRedirectFailure())
+
+	model.SetRedirectSuccess(exampleRedirectSuccess)
+	assert.True(t, model.HasRedirectSuccess())
+	assert.Equal(t, exampleRedirectSuccess, model.GetRedirectSuccess())
+
+	model.SetToken(exampleToken)
+	assert.True(t, model.HasToken())
+	assert.Equal(t, exampleToken, model.GetToken())
+}
+
+func TestDirectTokenAuthRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDirectTokenAuthRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DirectTokenAuthRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasToken())
+	assert.Equal(t, exampleToken, unmarshalled.GetToken())
+}
+
+func TestDirectTokenAuthRequestToMap(t *testing.T) {
+	model := buildExampleDirectTokenAuthRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "token") {
+		assert.Equal(t, &exampleToken, m["token"])
+	}
+}
+
+func TestNullableDirectTokenAuthRequestGetSet(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NullableDirectTokenAuthRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDirectTokenAuthRequestUnset(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NewNullableDirectTokenAuthRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDirectTokenAuthRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NewNullableDirectTokenAuthRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDirectTokenAuthRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleToken, newN.Get().GetToken())
+	}
+}

--- a/test/model/model_domain_key_check_request_test.go
+++ b/test/model/model_domain_key_check_request_test.go
@@ -1,0 +1,88 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDomainKey = "ABCDEF"
+
+func buildExampleDomainKeyCheckRequest() *openapiclient.DomainKeyCheckRequest {
+	return openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+}
+
+func TestNewDomainKeyCheckRequest(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDomainKey, model.GetDomainKey())
+}
+
+func TestNewDomainKeyCheckRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetDomainKey())
+}
+
+func TestDomainKeyCheckRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+	model.SetDomainKey("XYZ")
+	assert.Equal(t, "XYZ", model.GetDomainKey())
+	if val, ok := model.GetDomainKeyOk(); assert.True(t, ok) {
+		assert.Equal(t, "XYZ", *val)
+	}
+}
+
+func TestDomainKeyCheckRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyCheckRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyCheckRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleDomainKey, unmarshalled.GetDomainKey())
+}
+
+func TestDomainKeyCheckRequestToMap(t *testing.T) {
+	model := buildExampleDomainKeyCheckRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain_key") {
+		assert.Equal(t, exampleDomainKey, m["domain_key"])
+	}
+}
+
+func TestNullableDomainKeyCheckRequestGetSet(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NullableDomainKeyCheckRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyCheckRequestUnset(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NewNullableDomainKeyCheckRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyCheckRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NewNullableDomainKeyCheckRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyCheckRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleDomainKey, newN.Get().GetDomainKey())
+	}
+}

--- a/test/model/model_domain_key_request_test.go
+++ b/test/model/model_domain_key_request_test.go
@@ -1,0 +1,106 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDomain = []string{"example.com"}
+var exampleLive = true
+var exampleMerchantID int32 = 50
+
+func buildExampleDomainKeyRequest() *openapiclient.DomainKeyRequest {
+	d := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	d.SetLive(exampleLive)
+	return d
+}
+
+func TestNewDomainKeyRequest(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDomain, model.GetDomain())
+	assert.Equal(t, exampleMerchantID, model.GetMerchantid())
+	assert.False(t, model.HasLive())
+}
+
+func TestNewDomainKeyRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, 0, len(model.GetDomain()))
+	assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestDomainKeyRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	model.SetDomain([]string{"new.com"})
+	assert.Equal(t, []string{"new.com"}, model.GetDomain())
+
+	model.SetLive(exampleLive)
+	assert.True(t, model.HasLive())
+	assert.Equal(t, exampleLive, model.GetLive())
+	if val, ok := model.GetLiveOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleLive, *val)
+	}
+
+	model.SetMerchantid(99)
+	assert.Equal(t, int32(99), model.GetMerchantid())
+}
+
+func TestDomainKeyRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleMerchantID, unmarshalled.GetMerchantid())
+	assert.True(t, unmarshalled.HasLive())
+}
+
+func TestDomainKeyRequestToMap(t *testing.T) {
+	model := buildExampleDomainKeyRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain") {
+		assert.Equal(t, exampleDomain, m["domain"])
+	}
+	if assert.Contains(t, m, "live") {
+		assert.Equal(t, &exampleLive, m["live"])
+	}
+}
+
+func TestNullableDomainKeyRequestGetSet(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NullableDomainKeyRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyRequestUnset(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NewNullableDomainKeyRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NewNullableDomainKeyRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMerchantID, newN.Get().GetMerchantid())
+	}
+}

--- a/test/model/model_domain_key_response_test.go
+++ b/test/model/model_domain_key_response_test.go
@@ -1,0 +1,116 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleRespDomain = []string{"example.com"}
+var exampleRespDate = time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+var exampleRespDomainKey = "KEY"
+var exampleRespLive = true
+var exampleRespMerchant int32 = 55
+
+func buildExampleDomainKeyResponse() *openapiclient.DomainKeyResponse {
+	d := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	d.SetDateCreated(exampleRespDate)
+	d.SetDomainKey(exampleRespDomainKey)
+	d.SetLive(exampleRespLive)
+	return d
+}
+
+func TestNewDomainKeyResponse(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleRespDomain, model.GetDomain())
+	assert.Equal(t, exampleRespMerchant, model.GetMerchantid())
+	assert.False(t, model.HasDomainKey())
+}
+
+func TestNewDomainKeyResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, 0, len(model.GetDomain()))
+	assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestDomainKeyResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	model.SetDateCreated(exampleRespDate)
+	assert.True(t, model.HasDateCreated())
+	assert.Equal(t, exampleRespDate, model.GetDateCreated())
+
+	model.SetDomain(exampleRespDomain)
+	assert.Equal(t, exampleRespDomain, model.GetDomain())
+
+	model.SetDomainKey(exampleRespDomainKey)
+	assert.True(t, model.HasDomainKey())
+	assert.Equal(t, exampleRespDomainKey, model.GetDomainKey())
+
+	model.SetLive(exampleRespLive)
+	assert.True(t, model.HasLive())
+	assert.Equal(t, exampleRespLive, model.GetLive())
+
+	model.SetMerchantid(99)
+	assert.Equal(t, int32(99), model.GetMerchantid())
+}
+
+func TestDomainKeyResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasDomainKey())
+	assert.Equal(t, exampleRespDomainKey, unmarshalled.GetDomainKey())
+}
+
+func TestDomainKeyResponseToMap(t *testing.T) {
+	model := buildExampleDomainKeyResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain_key") {
+		assert.Equal(t, &exampleRespDomainKey, m["domain_key"])
+	}
+	if assert.Contains(t, m, "live") {
+		assert.Equal(t, &exampleRespLive, m["live"])
+	}
+}
+
+func TestNullableDomainKeyResponseGetSet(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NullableDomainKeyResponse{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyResponseUnset(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NewNullableDomainKeyResponse(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NewNullableDomainKeyResponse(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRespDomainKey, newN.Get().GetDomainKey())
+	}
+}

--- a/test/model/model_error_test.go
+++ b/test/model/model_error_test.go
@@ -1,0 +1,117 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleErrCode = "E001"
+var exampleErrContext = "CTX"
+var exampleErrId = "ID123"
+var exampleErrMsg = "message"
+var exampleErrDate = time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+func buildExampleError() *openapiclient.Error {
+	e := openapiclient.NewError()
+	e.SetCode(exampleErrCode)
+	e.SetContext(exampleErrContext)
+	e.SetIdentifier(exampleErrId)
+	e.SetMessage(exampleErrMsg)
+	e.SetResponseDt(exampleErrDate)
+	return e
+}
+
+func TestNewError(t *testing.T) {
+	model := openapiclient.NewError()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+}
+
+func TestNewErrorWithDefaults(t *testing.T) {
+	model := openapiclient.NewErrorWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+}
+
+func TestErrorSetGetCycle(t *testing.T) {
+	model := openapiclient.NewError()
+	model.SetCode(exampleErrCode)
+	assert.True(t, model.HasCode())
+	assert.Equal(t, exampleErrCode, model.GetCode())
+
+	model.SetContext(exampleErrContext)
+	assert.True(t, model.HasContext())
+	assert.Equal(t, exampleErrContext, model.GetContext())
+
+	model.SetIdentifier(exampleErrId)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleErrId, model.GetIdentifier())
+
+	model.SetMessage(exampleErrMsg)
+	assert.True(t, model.HasMessage())
+	assert.Equal(t, exampleErrMsg, model.GetMessage())
+
+	model.SetResponseDt(exampleErrDate)
+	assert.True(t, model.HasResponseDt())
+	assert.Equal(t, exampleErrDate, model.GetResponseDt())
+}
+
+func TestErrorJSONRoundTrip(t *testing.T) {
+	model := buildExampleError()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Error
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCode())
+	assert.Equal(t, exampleErrCode, unmarshalled.GetCode())
+}
+
+func TestErrorToMap(t *testing.T) {
+	model := buildExampleError()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "code") {
+		assert.Equal(t, &exampleErrCode, m["code"])
+	}
+	if assert.Contains(t, m, "response_dt") {
+		assert.Equal(t, &exampleErrDate, m["response_dt"])
+	}
+}
+
+func TestNullableErrorGetSet(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NullableError{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableErrorUnset(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NewNullableError(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableErrorJSONRoundTrip(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NewNullableError(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableError
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleErrCode, newN.Get().GetCode())
+	}
+}

--- a/test/model/model_event_data_model_test.go
+++ b/test/model/model_event_data_model_test.go
@@ -1,0 +1,116 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleEndDate = "2024-12-31"
+var exampleEventId = "EVT1"
+var exampleOrganiser = "ORG1"
+var exampleStartDate = "2024-01-01"
+var examplePayType = "deposit"
+
+func buildExampleEventDataModel() *openapiclient.EventDataModel {
+	e := openapiclient.NewEventDataModel()
+	e.SetEventEndDate(exampleEndDate)
+	e.SetEventId(exampleEventId)
+	e.SetEventOrganiserId(exampleOrganiser)
+	e.SetEventStartDate(exampleStartDate)
+	e.SetPaymentType(examplePayType)
+	return e
+}
+
+func TestNewEventDataModel(t *testing.T) {
+	model := openapiclient.NewEventDataModel()
+	require.NotNil(t, model)
+	assert.False(t, model.HasEventId())
+}
+
+func TestNewEventDataModelWithDefaults(t *testing.T) {
+	model := openapiclient.NewEventDataModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasEventId())
+}
+
+func TestEventDataModelSetGetCycle(t *testing.T) {
+	model := openapiclient.NewEventDataModel()
+	model.SetEventEndDate(exampleEndDate)
+	assert.True(t, model.HasEventEndDate())
+	assert.Equal(t, exampleEndDate, model.GetEventEndDate())
+
+	model.SetEventId(exampleEventId)
+	assert.True(t, model.HasEventId())
+	assert.Equal(t, exampleEventId, model.GetEventId())
+
+	model.SetEventOrganiserId(exampleOrganiser)
+	assert.True(t, model.HasEventOrganiserId())
+	assert.Equal(t, exampleOrganiser, model.GetEventOrganiserId())
+
+	model.SetEventStartDate(exampleStartDate)
+	assert.True(t, model.HasEventStartDate())
+	assert.Equal(t, exampleStartDate, model.GetEventStartDate())
+
+	model.SetPaymentType(examplePayType)
+	assert.True(t, model.HasPaymentType())
+	assert.Equal(t, examplePayType, model.GetPaymentType())
+}
+
+func TestEventDataModelJSONRoundTrip(t *testing.T) {
+	model := buildExampleEventDataModel()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.EventDataModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleEventId, unmarshalled.GetEventId())
+	assert.True(t, unmarshalled.HasEventEndDate())
+}
+
+func TestEventDataModelToMap(t *testing.T) {
+	model := buildExampleEventDataModel()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "event_id") {
+		assert.Equal(t, &exampleEventId, m["event_id"])
+	}
+	if assert.Contains(t, m, "payment_type") {
+		assert.Equal(t, &examplePayType, m["payment_type"])
+	}
+}
+
+func TestNullableEventDataModelGetSet(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NullableEventDataModel{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableEventDataModelUnset(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NewNullableEventDataModel(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableEventDataModelJSONRoundTrip(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NewNullableEventDataModel(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableEventDataModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleEventId, newN.Get().GetEventId())
+	}
+}

--- a/test/model/model_exists_test.go
+++ b/test/model/model_exists_test.go
@@ -1,0 +1,105 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleExistsActive = true
+var exampleExistsValue = true
+var exampleExistsDate = time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC)
+
+func buildExampleExists() *openapiclient.Exists {
+	e := openapiclient.NewExists(exampleExistsValue)
+	e.SetActive(exampleExistsActive)
+	e.SetLastModified(exampleExistsDate)
+	return e
+}
+
+func TestNewExists(t *testing.T) {
+	model := openapiclient.NewExists(exampleExistsValue)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleExistsValue, model.GetExists())
+	assert.False(t, model.HasActive())
+}
+
+func TestNewExistsWithDefaults(t *testing.T) {
+	model := openapiclient.NewExistsWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasActive())
+	assert.Equal(t, false, model.GetExists())
+}
+
+func TestExistsSetGetCycle(t *testing.T) {
+	model := openapiclient.NewExists(false)
+	model.SetActive(exampleExistsActive)
+	assert.True(t, model.HasActive())
+	assert.Equal(t, exampleExistsActive, model.GetActive())
+
+	model.SetExists(exampleExistsValue)
+	assert.Equal(t, exampleExistsValue, model.GetExists())
+
+	model.SetLastModified(exampleExistsDate)
+	assert.True(t, model.HasLastModified())
+	assert.Equal(t, exampleExistsDate, model.GetLastModified())
+}
+
+func TestExistsJSONRoundTrip(t *testing.T) {
+	model := buildExampleExists()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Exists
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasActive())
+	assert.Equal(t, exampleExistsDate, unmarshalled.GetLastModified())
+}
+
+func TestExistsToMap(t *testing.T) {
+	model := buildExampleExists()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "active") {
+		assert.Equal(t, &exampleExistsActive, m["active"])
+	}
+	if assert.Contains(t, m, "exists") {
+		assert.Equal(t, exampleExistsValue, m["exists"])
+	}
+}
+
+func TestNullableExistsGetSet(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NullableExists{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableExistsUnset(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NewNullableExists(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableExistsJSONRoundTrip(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NewNullableExists(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableExists
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleExistsValue, newN.Get().GetExists())
+	}
+}


### PR DESCRIPTION
## Summary
- add test suites for Acknowledgement, AclCheckRequest, AclCheckResponseModel, AirlineAdvice and AirlineSegment models

## Testing
- _No tests run_

------
https://chatgpt.com/codex/tasks/task_b_6876573f30148331a24e460fff0d6e35