### PR TITLE
Add tests for additional models

### DIFF
--- a/test/model/model_account_create_test.go
+++ b/test/model/model_account_create_test.go
@@ -1,0 +1,127 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// helper to build example contact details
+func buildExampleContact() openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1("123 Example Road")
+	c.SetEmail("test@example.com")
+	c.SetFirstname("Jane")
+	c.SetLastname("Doe")
+	c.SetCountry("GB")
+	return *c
+}
+
+var exampleAccountID = "acc123"
+
+func TestNewAccountCreate(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleAccountID, model.GetAccountId())
+	assert.False(t, model.HasContact())
+	contact, ok := model.GetContactOk()
+	assert.False(t, ok)
+	assert.Nil(t, contact)
+}
+
+func TestNewAccountCreateWithDefaults(t *testing.T) {
+	model := openapiclient.NewAccountCreateWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetAccountId())
+	assert.False(t, model.HasContact())
+}
+
+func TestAccountCreateSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	model.SetAccountId("updated")
+	assert.Equal(t, "updated", model.GetAccountId())
+	id, ok := model.GetAccountIdOk()
+	require.True(t, ok)
+	if assert.NotNil(t, id) {
+		assert.Equal(t, "updated", *id)
+	}
+
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	assert.True(t, model.HasContact())
+	got := model.GetContact()
+	assert.Equal(t, contact, got)
+	gotPtr, ok := model.GetContactOk()
+	require.True(t, ok)
+	if assert.NotNil(t, gotPtr) {
+		assert.Equal(t, contact, *gotPtr)
+	}
+}
+
+func TestAccountCreateJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AccountCreate
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAccountID, unmarshalled.GetAccountId())
+	assert.True(t, unmarshalled.HasContact())
+	assert.Equal(t, contact, unmarshalled.GetContact())
+}
+
+func TestAccountCreateToMap(t *testing.T) {
+	model := openapiclient.NewAccountCreate(exampleAccountID)
+	contact := buildExampleContact()
+	model.SetContact(contact)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "account_id") {
+		assert.Equal(t, exampleAccountID, m["account_id"])
+	}
+	if assert.Contains(t, m, "contact") {
+		if assert.NotNil(t, m["contact"]) {
+			assert.Equal(t, &contact, m["contact"])
+		}
+	}
+}
+
+func TestNullableAccountCreateGetSet(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	base.SetContact(buildExampleContact())
+	n := openapiclient.NullableAccountCreate{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAccountCreateUnset(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	n := openapiclient.NewNullableAccountCreate(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAccountCreateJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAccountCreate(exampleAccountID)
+	base.SetContact(buildExampleContact())
+	n := openapiclient.NewNullableAccountCreate(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAccountCreate
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, base.GetAccountId(), newN.Get().GetAccountId())
+		assert.Equal(t, base.GetContact(), newN.Get().GetContact())
+	}
+}

--- a/test/model/model_account_status_test.go
+++ b/test/model/model_account_status_test.go
@@ -1,0 +1,98 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// example data used across tests
+var exampleStatus = "ACTIVE"
+
+func TestNewAccountStatus(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	require.NotNil(t, model)
+	assert.False(t, model.HasStatus())
+	assert.Equal(t, "", model.GetStatus())
+	val, ok := model.GetStatusOk()
+	assert.False(t, ok)
+	assert.Nil(t, val)
+}
+
+func TestNewAccountStatusWithDefaults(t *testing.T) {
+	model := openapiclient.NewAccountStatusWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasStatus())
+	assert.Equal(t, "", model.GetStatus())
+}
+
+func TestAccountStatusSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	assert.True(t, model.HasStatus())
+	assert.Equal(t, exampleStatus, model.GetStatus())
+	val, ok := model.GetStatusOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, exampleStatus, *val)
+	}
+}
+
+func TestAccountStatusJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AccountStatus
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasStatus())
+	assert.Equal(t, exampleStatus, unmarshalled.GetStatus())
+}
+
+func TestAccountStatusToMap(t *testing.T) {
+	model := openapiclient.NewAccountStatus()
+	model.SetStatus(exampleStatus)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "status") {
+		assert.Equal(t, &exampleStatus, m["status"])
+	}
+}
+
+func TestNullableAccountStatusGetSet(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	base.SetStatus(exampleStatus)
+	n := openapiclient.NullableAccountStatus{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAccountStatusUnset(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	n := openapiclient.NewNullableAccountStatus(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAccountStatusJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAccountStatus()
+	base.SetStatus(exampleStatus)
+	n := openapiclient.NewNullableAccountStatus(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAccountStatus
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleStatus, newN.Get().GetStatus())
+	}
+}

--- a/test/model/model_acknowledgement_test.go
+++ b/test/model/model_acknowledgement_test.go
@@ -1,0 +1,132 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAckCode = "200"
+var exampleAckContext = "ctx1"
+var exampleAckIdentifier = "id1"
+var exampleAckMessage = "OK"
+
+func buildExampleAcknowledgement() *openapiclient.Acknowledgement {
+	a := openapiclient.NewAcknowledgement()
+	a.SetCode(exampleAckCode)
+	a.SetContext(exampleAckContext)
+	a.SetIdentifier(exampleAckIdentifier)
+	a.SetMessage(exampleAckMessage)
+	return a
+}
+
+func TestNewAcknowledgement(t *testing.T) {
+	model := openapiclient.NewAcknowledgement()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+	assert.False(t, model.HasContext())
+	assert.False(t, model.HasIdentifier())
+	assert.False(t, model.HasMessage())
+}
+
+func TestNewAcknowledgementWithDefaults(t *testing.T) {
+	model := openapiclient.NewAcknowledgementWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+	assert.False(t, model.HasContext())
+	assert.False(t, model.HasIdentifier())
+	assert.False(t, model.HasMessage())
+}
+
+func TestAcknowledgementSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAcknowledgement()
+	model.SetCode(exampleAckCode)
+	assert.True(t, model.HasCode())
+	assert.Equal(t, exampleAckCode, model.GetCode())
+	val, ok := model.GetCodeOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, exampleAckCode, *val)
+	}
+
+	model.SetContext(exampleAckContext)
+	assert.True(t, model.HasContext())
+	assert.Equal(t, exampleAckContext, model.GetContext())
+
+	model.SetIdentifier(exampleAckIdentifier)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleAckIdentifier, model.GetIdentifier())
+
+	model.SetMessage(exampleAckMessage)
+	assert.True(t, model.HasMessage())
+	assert.Equal(t, exampleAckMessage, model.GetMessage())
+}
+
+func TestAcknowledgementJSONRoundTrip(t *testing.T) {
+	model := buildExampleAcknowledgement()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Acknowledgement
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAckCode, unmarshalled.GetCode())
+	assert.Equal(t, exampleAckContext, unmarshalled.GetContext())
+	assert.Equal(t, exampleAckIdentifier, unmarshalled.GetIdentifier())
+	assert.Equal(t, exampleAckMessage, unmarshalled.GetMessage())
+}
+
+func TestAcknowledgementToMap(t *testing.T) {
+	model := buildExampleAcknowledgement()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "code") {
+		assert.Equal(t, &exampleAckCode, m["code"])
+	}
+	if assert.Contains(t, m, "context") {
+		assert.Equal(t, &exampleAckContext, m["context"])
+	}
+	if assert.Contains(t, m, "identifier") {
+		assert.Equal(t, &exampleAckIdentifier, m["identifier"])
+	}
+	if assert.Contains(t, m, "message") {
+		assert.Equal(t, &exampleAckMessage, m["message"])
+	}
+}
+
+func TestNullableAcknowledgementGetSet(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NullableAcknowledgement{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAcknowledgementUnset(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NewNullableAcknowledgement(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAcknowledgementJSONRoundTrip(t *testing.T) {
+	base := buildExampleAcknowledgement()
+	n := openapiclient.NewNullableAcknowledgement(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAcknowledgement
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAckCode, newN.Get().GetCode())
+		assert.Equal(t, exampleAckContext, newN.Get().GetContext())
+		assert.Equal(t, exampleAckIdentifier, newN.Get().GetIdentifier())
+		assert.Equal(t, exampleAckMessage, newN.Get().GetMessage())
+	}
+}

--- a/test/model/model_acl_check_request_test.go
+++ b/test/model/model_acl_check_request_test.go
@@ -1,0 +1,86 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAclRequestIP = "192.0.2.1"
+
+func TestNewAclCheckRequest(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleAclRequestIP, model.GetIp())
+}
+
+func TestNewAclCheckRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewAclCheckRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetIp())
+}
+
+func TestAclCheckRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	model.SetIp("203.0.113.5")
+	assert.Equal(t, "203.0.113.5", model.GetIp())
+	val, ok := model.GetIpOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, "203.0.113.5", *val)
+	}
+}
+
+func TestAclCheckRequestJSONRoundTrip(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AclCheckRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAclRequestIP, unmarshalled.GetIp())
+}
+
+func TestAclCheckRequestToMap(t *testing.T) {
+	model := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "ip") {
+		assert.Equal(t, exampleAclRequestIP, m["ip"])
+	}
+}
+
+func TestNullableAclCheckRequestGetSet(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NullableAclCheckRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAclCheckRequestUnset(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NewNullableAclCheckRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAclCheckRequestJSONRoundTrip(t *testing.T) {
+	base := openapiclient.NewAclCheckRequest(exampleAclRequestIP)
+	n := openapiclient.NewNullableAclCheckRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAclCheckRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAclRequestIP, newN.Get().GetIp())
+	}
+}

--- a/test/model/model_acl_check_response_model_test.go
+++ b/test/model/model_acl_check_response_model_test.go
@@ -1,0 +1,127 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAclName = "Public"
+var exampleAclCache = true
+var exampleAclIP = "192.0.2.1"
+var exampleAclProvider = "cloud"
+
+func buildExampleAclCheckResponse() *openapiclient.AclCheckResponseModel {
+	m := openapiclient.NewAclCheckResponseModel()
+	m.SetAcl(exampleAclName)
+	m.SetCache(exampleAclCache)
+	m.SetIp(exampleAclIP)
+	m.SetProvider(exampleAclProvider)
+	return m
+}
+
+func TestNewAclCheckResponseModel(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModel()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAcl())
+	assert.False(t, model.HasCache())
+	assert.False(t, model.HasIp())
+	assert.False(t, model.HasProvider())
+}
+
+func TestNewAclCheckResponseModelWithDefaults(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAcl())
+	assert.False(t, model.HasCache())
+	assert.False(t, model.HasIp())
+	assert.False(t, model.HasProvider())
+}
+
+func TestAclCheckResponseModelSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAclCheckResponseModel()
+	model.SetAcl(exampleAclName)
+	assert.True(t, model.HasAcl())
+	assert.Equal(t, exampleAclName, model.GetAcl())
+
+	model.SetCache(exampleAclCache)
+	assert.True(t, model.HasCache())
+	assert.Equal(t, exampleAclCache, model.GetCache())
+
+	model.SetIp(exampleAclIP)
+	assert.True(t, model.HasIp())
+	assert.Equal(t, exampleAclIP, model.GetIp())
+
+	model.SetProvider(exampleAclProvider)
+	assert.True(t, model.HasProvider())
+	assert.Equal(t, exampleAclProvider, model.GetProvider())
+}
+
+func TestAclCheckResponseModelJSONRoundTrip(t *testing.T) {
+	model := buildExampleAclCheckResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AclCheckResponseModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAclName, unmarshalled.GetAcl())
+	assert.Equal(t, exampleAclCache, unmarshalled.GetCache())
+	assert.Equal(t, exampleAclIP, unmarshalled.GetIp())
+	assert.Equal(t, exampleAclProvider, unmarshalled.GetProvider())
+}
+
+func TestAclCheckResponseModelToMap(t *testing.T) {
+	model := buildExampleAclCheckResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "acl") {
+		assert.Equal(t, &exampleAclName, m["acl"])
+	}
+	if assert.Contains(t, m, "cache") {
+		assert.Equal(t, &exampleAclCache, m["cache"])
+	}
+	if assert.Contains(t, m, "ip") {
+		assert.Equal(t, &exampleAclIP, m["ip"])
+	}
+	if assert.Contains(t, m, "provider") {
+		assert.Equal(t, &exampleAclProvider, m["provider"])
+	}
+}
+
+func TestNullableAclCheckResponseModelGetSet(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NullableAclCheckResponseModel{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAclCheckResponseModelUnset(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NewNullableAclCheckResponseModel(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAclCheckResponseModelJSONRoundTrip(t *testing.T) {
+	base := buildExampleAclCheckResponse()
+	n := openapiclient.NewNullableAclCheckResponseModel(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAclCheckResponseModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAclName, newN.Get().GetAcl())
+		assert.Equal(t, exampleAclCache, newN.Get().GetCache())
+		assert.Equal(t, exampleAclIP, newN.Get().GetIp())
+		assert.Equal(t, exampleAclProvider, newN.Get().GetProvider())
+	}
+}

--- a/test/model/model_airline_advice_test.go
+++ b/test/model/model_airline_advice_test.go
@@ -1,0 +1,158 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleCarrierName = "Airline"
+var exampleTicketIssueCity = "London"
+var exampleTicketIssueDate = "2023-01-05"
+var exampleTicketIssueName = "Agency"
+var exampleTicketNo = "1234567890123"
+var exampleTransactionType = "TKT"
+var examplePassengerName = "John Doe"
+var exampleOriginalTicketNo = "9876543210987"
+var exampleNoAirSegments int32 = 2
+var exampleNumberInParty int32 = 1
+var exampleConjunctionIndicator = true
+var exampleEticketIndicator = false
+
+func buildExampleAdvice() *openapiclient.AirlineAdvice {
+	seg1 := buildExampleSegment()
+	seg2 := buildExampleSegment()
+	a := openapiclient.NewAirlineAdvice(exampleCarrierName, seg1, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	a.SetConjunctionTicketIndicator(exampleConjunctionIndicator)
+	a.SetEticketIndicator(exampleEticketIndicator)
+	a.SetNoAirSegments(exampleNoAirSegments)
+	a.SetNumberInParty(exampleNumberInParty)
+	a.SetOriginalTicketNo(exampleOriginalTicketNo)
+	a.SetPassengerName(examplePassengerName)
+	a.SetSegment2(seg2)
+	return a
+}
+
+func TestNewAirlineAdvice(t *testing.T) {
+	seg := buildExampleSegment()
+	model := openapiclient.NewAirlineAdvice(exampleCarrierName, seg, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleCarrierName, model.GetCarrierName())
+	assert.False(t, model.HasConjunctionTicketIndicator())
+	assert.False(t, model.HasEticketIndicator())
+	assert.False(t, model.HasNoAirSegments())
+	assert.False(t, model.HasNumberInParty())
+	assert.False(t, model.HasOriginalTicketNo())
+	assert.False(t, model.HasPassengerName())
+	assert.False(t, model.HasSegment2())
+	assert.False(t, model.HasSegment3())
+	assert.False(t, model.HasSegment4())
+}
+
+func TestNewAirlineAdviceWithDefaults(t *testing.T) {
+	model := openapiclient.NewAirlineAdviceWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetCarrierName())
+	assert.False(t, model.HasConjunctionTicketIndicator())
+}
+
+func TestAirlineAdviceSetGetCycle(t *testing.T) {
+	seg := buildExampleSegment()
+	model := openapiclient.NewAirlineAdvice(exampleCarrierName, seg, exampleTicketIssueCity, exampleTicketIssueDate, exampleTicketIssueName, exampleTicketNo, exampleTransactionType)
+	model.SetCarrierName("NewAir")
+	assert.Equal(t, "NewAir", model.GetCarrierName())
+
+	model.SetConjunctionTicketIndicator(exampleConjunctionIndicator)
+	assert.True(t, model.HasConjunctionTicketIndicator())
+	assert.Equal(t, exampleConjunctionIndicator, model.GetConjunctionTicketIndicator())
+
+	model.SetEticketIndicator(exampleEticketIndicator)
+	assert.True(t, model.HasEticketIndicator())
+	assert.Equal(t, exampleEticketIndicator, model.GetEticketIndicator())
+
+	model.SetNoAirSegments(exampleNoAirSegments)
+	assert.True(t, model.HasNoAirSegments())
+	assert.Equal(t, exampleNoAirSegments, model.GetNoAirSegments())
+
+	model.SetNumberInParty(exampleNumberInParty)
+	assert.True(t, model.HasNumberInParty())
+	assert.Equal(t, exampleNumberInParty, model.GetNumberInParty())
+
+	model.SetOriginalTicketNo(exampleOriginalTicketNo)
+	assert.True(t, model.HasOriginalTicketNo())
+	assert.Equal(t, exampleOriginalTicketNo, model.GetOriginalTicketNo())
+
+	model.SetPassengerName(examplePassengerName)
+	assert.True(t, model.HasPassengerName())
+	assert.Equal(t, examplePassengerName, model.GetPassengerName())
+
+	seg2 := buildExampleSegment()
+	model.SetSegment2(seg2)
+	assert.True(t, model.HasSegment2())
+	assert.Equal(t, seg2, model.GetSegment2())
+}
+
+func TestAirlineAdviceJSONRoundTrip(t *testing.T) {
+	model := buildExampleAdvice()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AirlineAdvice
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleCarrierName, unmarshalled.GetCarrierName())
+	assert.True(t, unmarshalled.HasConjunctionTicketIndicator())
+	assert.Equal(t, exampleConjunctionIndicator, unmarshalled.GetConjunctionTicketIndicator())
+	assert.True(t, unmarshalled.HasSegment2())
+}
+
+func TestAirlineAdviceToMap(t *testing.T) {
+	model := buildExampleAdvice()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "carrier_name") {
+		assert.Equal(t, exampleCarrierName, m["carrier_name"])
+	}
+	if assert.Contains(t, m, "conjunction_ticket_indicator") {
+		assert.Equal(t, &exampleConjunctionIndicator, m["conjunction_ticket_indicator"])
+	}
+	if assert.Contains(t, m, "segment2") {
+		if assert.NotNil(t, m["segment2"]) {
+			assert.Equal(t, model.GetSegment2(), *m["segment2"].(*openapiclient.AirlineSegment))
+		}
+	}
+}
+
+func TestNullableAirlineAdviceGetSet(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NullableAirlineAdvice{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAirlineAdviceUnset(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NewNullableAirlineAdvice(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAirlineAdviceJSONRoundTrip(t *testing.T) {
+	base := buildExampleAdvice()
+	n := openapiclient.NewNullableAirlineAdvice(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAirlineAdvice
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleCarrierName, newN.Get().GetCarrierName())
+	}
+}

--- a/test/model/model_airline_segment_test.go
+++ b/test/model/model_airline_segment_test.go
@@ -1,0 +1,165 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleSegArrival = "LHR"
+var exampleSegCarrier = "BA"
+var exampleSegClass = "E"
+var exampleSegDate = "2023-01-01"
+var exampleSegDeparture = "JFK"
+var exampleSegFlight = "BA123"
+var exampleSegFare int32 = 100
+var exampleSegStop = "O"
+
+func buildExampleSegment() openapiclient.AirlineSegment {
+	s := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	s.SetDepartureLocationCode(exampleSegDeparture)
+	s.SetSegmentFare(exampleSegFare)
+	s.SetStopOverIndicator(exampleSegStop)
+	return *s
+}
+
+func TestNewAirlineSegment(t *testing.T) {
+	model := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleSegArrival, model.GetArrivalLocationCode())
+	assert.Equal(t, exampleSegCarrier, model.GetCarrierCode())
+	assert.False(t, model.HasDepartureLocationCode())
+	assert.False(t, model.HasSegmentFare())
+	assert.False(t, model.HasStopOverIndicator())
+}
+
+func TestNewAirlineSegmentWithDefaults(t *testing.T) {
+	model := openapiclient.NewAirlineSegmentWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetArrivalLocationCode())
+	assert.Equal(t, "", model.GetCarrierCode())
+	assert.False(t, model.HasDepartureLocationCode())
+	assert.False(t, model.HasSegmentFare())
+	assert.False(t, model.HasStopOverIndicator())
+}
+
+func TestAirlineSegmentSetGetCycle(t *testing.T) {
+	model := openapiclient.NewAirlineSegment(exampleSegArrival, exampleSegCarrier, exampleSegClass, exampleSegDate, exampleSegFlight)
+	model.SetArrivalLocationCode("AAA")
+	assert.Equal(t, "AAA", model.GetArrivalLocationCode())
+	val, ok := model.GetArrivalLocationCodeOk()
+	require.True(t, ok)
+	if assert.NotNil(t, val) {
+		assert.Equal(t, "AAA", *val)
+	}
+
+	model.SetCarrierCode("CC")
+	assert.Equal(t, "CC", model.GetCarrierCode())
+
+	model.SetClassServiceCode("B")
+	assert.Equal(t, "B", model.GetClassServiceCode())
+
+	model.SetDepartureDate("2023-02-01")
+	assert.Equal(t, "2023-02-01", model.GetDepartureDate())
+
+	model.SetDepartureLocationCode(exampleSegDeparture)
+	assert.True(t, model.HasDepartureLocationCode())
+	assert.Equal(t, exampleSegDeparture, model.GetDepartureLocationCode())
+
+	model.SetFlightNumber("FL001")
+	assert.Equal(t, "FL001", model.GetFlightNumber())
+
+	model.SetSegmentFare(exampleSegFare)
+	assert.True(t, model.HasSegmentFare())
+	assert.Equal(t, exampleSegFare, model.GetSegmentFare())
+
+	model.SetStopOverIndicator(exampleSegStop)
+	assert.True(t, model.HasStopOverIndicator())
+	assert.Equal(t, exampleSegStop, model.GetStopOverIndicator())
+}
+
+func TestAirlineSegmentJSONRoundTrip(t *testing.T) {
+	model := buildExampleSegment()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.AirlineSegment
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleSegArrival, unmarshalled.GetArrivalLocationCode())
+	assert.Equal(t, exampleSegCarrier, unmarshalled.GetCarrierCode())
+	assert.Equal(t, exampleSegClass, unmarshalled.GetClassServiceCode())
+	assert.Equal(t, exampleSegDate, unmarshalled.GetDepartureDate())
+	assert.True(t, unmarshalled.HasDepartureLocationCode())
+	assert.Equal(t, exampleSegDeparture, unmarshalled.GetDepartureLocationCode())
+	assert.Equal(t, exampleSegFlight, unmarshalled.GetFlightNumber())
+	assert.True(t, unmarshalled.HasSegmentFare())
+	assert.Equal(t, exampleSegFare, unmarshalled.GetSegmentFare())
+	assert.True(t, unmarshalled.HasStopOverIndicator())
+	assert.Equal(t, exampleSegStop, unmarshalled.GetStopOverIndicator())
+}
+
+func TestAirlineSegmentToMap(t *testing.T) {
+	model := buildExampleSegment()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "arrival_location_code") {
+		assert.Equal(t, exampleSegArrival, m["arrival_location_code"])
+	}
+	if assert.Contains(t, m, "carrier_code") {
+		assert.Equal(t, exampleSegCarrier, m["carrier_code"])
+	}
+	if assert.Contains(t, m, "class_service_code") {
+		assert.Equal(t, exampleSegClass, m["class_service_code"])
+	}
+	if assert.Contains(t, m, "departure_date") {
+		assert.Equal(t, exampleSegDate, m["departure_date"])
+	}
+	if assert.Contains(t, m, "departure_location_code") {
+		assert.Equal(t, &exampleSegDeparture, m["departure_location_code"])
+	}
+	if assert.Contains(t, m, "flight_number") {
+		assert.Equal(t, exampleSegFlight, m["flight_number"])
+	}
+	if assert.Contains(t, m, "segment_fare") {
+		assert.Equal(t, &exampleSegFare, m["segment_fare"])
+	}
+	if assert.Contains(t, m, "stop_over_indicator") {
+		assert.Equal(t, &exampleSegStop, m["stop_over_indicator"])
+	}
+}
+
+func TestNullableAirlineSegmentGetSet(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NullableAirlineSegment{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableAirlineSegmentUnset(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NewNullableAirlineSegment(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableAirlineSegmentJSONRoundTrip(t *testing.T) {
+	base := buildExampleSegment()
+	n := openapiclient.NewNullableAirlineSegment(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableAirlineSegment
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleSegArrival, newN.Get().GetArrivalLocationCode())
+		assert.Equal(t, exampleSegCarrier, newN.Get().GetCarrierCode())
+	}
+}

--- a/test/model/model_auth_reference_test.go
+++ b/test/model/model_auth_reference_test.go
@@ -1,0 +1,189 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleAuthRefAmount = "12.34"
+var exampleAuthRefAmountValue int32 = 1234
+var exampleAuthRefAtrn = "ATR123"
+var exampleAuthRefAuthcode = "AUTHCODE"
+var exampleAuthRefBatchno = "BN1"
+var exampleAuthRefCurrency = "GBP"
+var exampleAuthRefDatetime = time.Date(2023, time.January, 2, 15, 4, 5, 0, time.UTC)
+var exampleAuthRefIdentifier = "ID42"
+var exampleAuthRefMaskedpan = "411111******1111"
+var exampleAuthRefMerchantid int32 = 100
+var exampleAuthRefResult = "OK"
+var exampleAuthRefTransStatus = "Approved"
+var exampleAuthRefTransType = "SALE"
+var exampleAuthRefTransno int32 = 99
+
+func buildExampleAuthReference() *openapiclient.AuthReference {
+    a := openapiclient.NewAuthReference()
+    a.SetAmount(exampleAuthRefAmount)
+    a.SetAmountValue(exampleAuthRefAmountValue)
+    a.SetAtrn(exampleAuthRefAtrn)
+    a.SetAuthcode(exampleAuthRefAuthcode)
+    a.SetBatchno(exampleAuthRefBatchno)
+    a.SetCurrency(exampleAuthRefCurrency)
+    a.SetDatetime(exampleAuthRefDatetime)
+    a.SetIdentifier(exampleAuthRefIdentifier)
+    a.SetMaskedpan(exampleAuthRefMaskedpan)
+    a.SetMerchantid(exampleAuthRefMerchantid)
+    a.SetResult(exampleAuthRefResult)
+    a.SetTransStatus(exampleAuthRefTransStatus)
+    a.SetTransType(exampleAuthRefTransType)
+    a.SetTransno(exampleAuthRefTransno)
+    return a
+}
+
+func TestNewAuthReference(t *testing.T) {
+    model := openapiclient.NewAuthReference()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAmountValue())
+    assert.False(t, model.HasAtrn())
+    assert.False(t, model.HasAuthcode())
+    assert.False(t, model.HasBatchno())
+    assert.False(t, model.HasCurrency())
+    assert.False(t, model.HasDatetime())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasMaskedpan())
+    assert.False(t, model.HasMerchantid())
+    assert.False(t, model.HasResult())
+    assert.False(t, model.HasTransStatus())
+    assert.False(t, model.HasTransType())
+    assert.False(t, model.HasTransno())
+}
+
+func TestNewAuthReferenceWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthReferenceWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAmountValue())
+}
+
+func TestAuthReferenceSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthReference()
+    model.SetAmount(exampleAuthRefAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleAuthRefAmount, model.GetAmount())
+
+    model.SetAmountValue(exampleAuthRefAmountValue)
+    assert.True(t, model.HasAmountValue())
+    assert.Equal(t, exampleAuthRefAmountValue, model.GetAmountValue())
+
+    model.SetAtrn(exampleAuthRefAtrn)
+    assert.True(t, model.HasAtrn())
+    assert.Equal(t, exampleAuthRefAtrn, model.GetAtrn())
+
+    model.SetAuthcode(exampleAuthRefAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleAuthRefAuthcode, model.GetAuthcode())
+
+    model.SetBatchno(exampleAuthRefBatchno)
+    assert.True(t, model.HasBatchno())
+    assert.Equal(t, exampleAuthRefBatchno, model.GetBatchno())
+
+    model.SetCurrency(exampleAuthRefCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleAuthRefCurrency, model.GetCurrency())
+
+    model.SetDatetime(exampleAuthRefDatetime)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleAuthRefDatetime, model.GetDatetime())
+
+    model.SetIdentifier(exampleAuthRefIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleAuthRefIdentifier, model.GetIdentifier())
+
+    model.SetMaskedpan(exampleAuthRefMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    assert.Equal(t, exampleAuthRefMaskedpan, model.GetMaskedpan())
+
+    model.SetMerchantid(exampleAuthRefMerchantid)
+    assert.True(t, model.HasMerchantid())
+    assert.Equal(t, exampleAuthRefMerchantid, model.GetMerchantid())
+
+    model.SetResult(exampleAuthRefResult)
+    assert.True(t, model.HasResult())
+    assert.Equal(t, exampleAuthRefResult, model.GetResult())
+
+    model.SetTransStatus(exampleAuthRefTransStatus)
+    assert.True(t, model.HasTransStatus())
+    assert.Equal(t, exampleAuthRefTransStatus, model.GetTransStatus())
+
+    model.SetTransType(exampleAuthRefTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleAuthRefTransType, model.GetTransType())
+
+    model.SetTransno(exampleAuthRefTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleAuthRefTransno, model.GetTransno())
+}
+
+func TestAuthReferenceJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthReference()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthReference
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAmount())
+    assert.Equal(t, exampleAuthRefAmount, unmarshalled.GetAmount())
+    assert.True(t, unmarshalled.HasTransno())
+    assert.Equal(t, exampleAuthRefTransno, unmarshalled.GetTransno())
+}
+
+func TestAuthReferenceToMap(t *testing.T) {
+    model := buildExampleAuthReference()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleAuthRefAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "transno") {
+        assert.Equal(t, &exampleAuthRefTransno, m["transno"])
+    }
+}
+
+func TestNullableAuthReferenceGetSet(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NullableAuthReference{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthReferenceUnset(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NewNullableAuthReference(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthReferenceJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthReference()
+    n := openapiclient.NewNullableAuthReference(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthReference
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleAuthRefAtrn, newN.Get().GetAtrn())
+    }
+}
+

--- a/test/model/model_auth_references_test.go
+++ b/test/model/model_auth_references_test.go
@@ -1,0 +1,94 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func buildExampleAuthReferences() *openapiclient.AuthReferences {
+    ref := buildExampleAuthReference()
+    a := openapiclient.NewAuthReferences()
+    a.SetAuths([]openapiclient.AuthReference{*ref})
+    return a
+}
+
+func TestNewAuthReferences(t *testing.T) {
+    model := openapiclient.NewAuthReferences()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAuths())
+}
+
+func TestNewAuthReferencesWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthReferencesWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAuths())
+}
+
+func TestAuthReferencesSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthReferences()
+    ref := buildExampleAuthReference()
+    model.SetAuths([]openapiclient.AuthReference{*ref})
+    assert.True(t, model.HasAuths())
+    assert.Equal(t, 1, len(model.GetAuths()))
+}
+
+func TestAuthReferencesJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthReferences()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthReferences
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAuths())
+    assert.Equal(t, 1, len(unmarshalled.GetAuths()))
+}
+
+func TestAuthReferencesToMap(t *testing.T) {
+    model := buildExampleAuthReferences()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "auths") {
+        if assert.Len(t, m["auths"], 1) {
+            first := m["auths"].([]openapiclient.AuthReference)[0]
+            assert.Equal(t, exampleAuthRefAtrn, first.GetAtrn())
+        }
+    }
+}
+
+func TestNullableAuthReferencesGetSet(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NullableAuthReferences{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthReferencesUnset(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NewNullableAuthReferences(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthReferencesJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthReferences()
+    n := openapiclient.NewNullableAuthReferences(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthReferences
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, 1, len(newN.Get().GetAuths()))
+    }
+}
+

--- a/test/model/model_auth_request_test.go
+++ b/test/model/model_auth_request_test.go
@@ -1,0 +1,214 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleReqAmount int32 = 10000
+var exampleReqCard = "4111111111111111"
+var exampleReqExpMonth int32 = 12
+var exampleReqExpYear int32 = 25
+var exampleReqIdentifier = "REQ123"
+var exampleReqMerchantID int32 = 999
+var exampleReqAvsPostcodePolicy = "1"
+var exampleReqCsc = "999"
+var exampleReqCscPolicy = "2"
+var exampleReqCurrency = "USD"
+var exampleReqDuplicatePolicy = "1"
+var exampleReqMatchAvsa = "2"
+var exampleReqNameOnCard = "John Doe"
+var exampleReqTransInfo = "info"
+var exampleReqTransType = "SALE"
+var exampleReqTags = []string{"one", "two"}
+
+func buildExampleEventData() openapiclient.EventDataModel {
+    e := openapiclient.NewEventDataModel()
+    e.SetEventId("EVT")
+    return *e
+}
+
+func buildExampleExternalMPI() openapiclient.ExternalMPI {
+    e := openapiclient.NewExternalMPI()
+    e.SetEnrolled("Y")
+    return *e
+}
+
+func buildExampleMcc6012() openapiclient.MCC6012 {
+    m := openapiclient.NewMCC6012()
+    m.SetRecipientLastname("Smith")
+    return *m
+}
+
+func buildExampleThreeDSecure() openapiclient.ThreeDSecure {
+    t := openapiclient.NewThreeDSecure()
+    t.SetTdsPolicy("1")
+    return *t
+}
+
+func buildExampleAuthRequest() *openapiclient.AuthRequest {
+    r := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    r.SetAirlineData(*buildExampleAdvice())
+    r.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+    r.SetBillTo(buildExampleContact())
+    r.SetCsc(exampleReqCsc)
+    r.SetCscPolicy(exampleReqCscPolicy)
+    r.SetCurrency(exampleReqCurrency)
+    r.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+    r.SetEventManagement(buildExampleEventData())
+    r.SetExternalMpi(buildExampleExternalMPI())
+    r.SetMatchAvsa(exampleReqMatchAvsa)
+    r.SetMcc6012(buildExampleMcc6012())
+    r.SetNameOnCard(exampleReqNameOnCard)
+    r.SetShipTo(buildExampleContact())
+    r.SetTag(exampleReqTags)
+    r.SetThreedsecure(buildExampleThreeDSecure())
+    r.SetTransInfo(exampleReqTransInfo)
+    r.SetTransType(exampleReqTransType)
+    return r
+}
+
+func TestNewAuthRequest(t *testing.T) {
+    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleReqAmount, model.GetAmount())
+    assert.Equal(t, exampleReqCard, model.GetCardnumber())
+    assert.False(t, model.HasAirlineData())
+    assert.False(t, model.HasAvsPostcodePolicy())
+    assert.False(t, model.HasBillTo())
+    assert.False(t, model.HasCsc())
+}
+
+func TestNewAuthRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+    assert.Equal(t, "", model.GetCardnumber())
+    assert.False(t, model.HasAirlineData())
+}
+
+func TestAuthRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+    model.SetAirlineData(*buildExampleAdvice())
+    assert.True(t, model.HasAirlineData())
+
+    model.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+    assert.True(t, model.HasAvsPostcodePolicy())
+    assert.Equal(t, exampleReqAvsPostcodePolicy, model.GetAvsPostcodePolicy())
+
+    model.SetBillTo(buildExampleContact())
+    assert.True(t, model.HasBillTo())
+
+    model.SetCsc(exampleReqCsc)
+    assert.True(t, model.HasCsc())
+    assert.Equal(t, exampleReqCsc, model.GetCsc())
+
+    model.SetCscPolicy(exampleReqCscPolicy)
+    assert.True(t, model.HasCscPolicy())
+    assert.Equal(t, exampleReqCscPolicy, model.GetCscPolicy())
+
+    model.SetCurrency(exampleReqCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleReqCurrency, model.GetCurrency())
+
+    model.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+    assert.True(t, model.HasDuplicatePolicy())
+    assert.Equal(t, exampleReqDuplicatePolicy, model.GetDuplicatePolicy())
+
+    model.SetEventManagement(buildExampleEventData())
+    assert.True(t, model.HasEventManagement())
+
+    model.SetExternalMpi(buildExampleExternalMPI())
+    assert.True(t, model.HasExternalMpi())
+
+    model.SetMatchAvsa(exampleReqMatchAvsa)
+    assert.True(t, model.HasMatchAvsa())
+    assert.Equal(t, exampleReqMatchAvsa, model.GetMatchAvsa())
+
+    model.SetMcc6012(buildExampleMcc6012())
+    assert.True(t, model.HasMcc6012())
+
+    model.SetNameOnCard(exampleReqNameOnCard)
+    assert.True(t, model.HasNameOnCard())
+    assert.Equal(t, exampleReqNameOnCard, model.GetNameOnCard())
+
+    model.SetShipTo(buildExampleContact())
+    assert.True(t, model.HasShipTo())
+
+    model.SetTag(exampleReqTags)
+    assert.True(t, model.HasTag())
+    assert.Equal(t, exampleReqTags, model.GetTag())
+
+    model.SetThreedsecure(buildExampleThreeDSecure())
+    assert.True(t, model.HasThreedsecure())
+
+    model.SetTransInfo(exampleReqTransInfo)
+    assert.True(t, model.HasTransInfo())
+    assert.Equal(t, exampleReqTransInfo, model.GetTransInfo())
+
+    model.SetTransType(exampleReqTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleReqTransType, model.GetTransType())
+}
+
+func TestAuthRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleReqAmount, unmarshalled.GetAmount())
+    assert.True(t, unmarshalled.HasTag())
+    assert.Equal(t, exampleReqTransType, unmarshalled.GetTransType())
+}
+
+func TestAuthRequestToMap(t *testing.T) {
+    model := buildExampleAuthRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleReqAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "tag") {
+        assert.Equal(t, exampleReqTags, m["tag"])
+    }
+}
+
+func TestNullableAuthRequestGetSet(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NullableAuthRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthRequestUnset(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NewNullableAuthRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthRequest()
+    n := openapiclient.NewNullableAuthRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleReqIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_auth_response_test.go
+++ b/test/model/model_auth_response_test.go
@@ -1,0 +1,246 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleRespAmount int32 = 1000
+var exampleRespAtrn = "ATRN"
+var exampleRespAtsd = "A1"
+var exampleRespAuthcode = "ACODE"
+var exampleRespAuthenResult = "Y"
+var exampleRespAuthorised = true
+var exampleRespAvsResult = "Y"
+var exampleRespBinCommercial = true
+var exampleRespBinDebit = true
+var exampleRespBinDescription = "DEBIT"
+var exampleRespCavv = "CAVV"
+var exampleRespContext = "CTX"
+var exampleRespCscResult = "M"
+var exampleRespCurrency = "GBP"
+var exampleRespDatetime = time.Date(2023, time.March, 5, 10, 0, 0, 0, time.UTC)
+var exampleRespEci = "05"
+var exampleRespIdentifier = "ID1"
+var exampleRespLive = true
+var exampleRespMaskedpan = "411111******1111"
+var exampleRespMerchantid int32 = 321
+var exampleRespResult int32 = 1
+var exampleRespResultCode = "A"
+var exampleRespResultMessage = "Approved"
+var exampleRespScheme = "VISA"
+var exampleRespSchemeId = "VIS"
+var exampleRespSchemeLogo = "logo"
+var exampleRespSha256 = "hash"
+var exampleRespTransStatus = "APPROVED"
+var exampleRespTransno int32 = 55
+
+func buildExampleAuthResponse() *openapiclient.AuthResponse {
+    r := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    r.SetAmount(exampleRespAmount)
+    r.SetAtrn(exampleRespAtrn)
+    r.SetAtsd(exampleRespAtsd)
+    r.SetAuthcode(exampleRespAuthcode)
+    r.SetAuthenResult(exampleRespAuthenResult)
+    r.SetAuthorised(exampleRespAuthorised)
+    r.SetAvsResult(exampleRespAvsResult)
+    r.SetBinCommercial(exampleRespBinCommercial)
+    r.SetBinDebit(exampleRespBinDebit)
+    r.SetBinDescription(exampleRespBinDescription)
+    r.SetCavv(exampleRespCavv)
+    r.SetContext(exampleRespContext)
+    r.SetCscResult(exampleRespCscResult)
+    r.SetCurrency(exampleRespCurrency)
+    r.SetDatetime(exampleRespDatetime)
+    r.SetEci(exampleRespEci)
+    r.SetIdentifier(exampleRespIdentifier)
+    r.SetLive(exampleRespLive)
+    r.SetMaskedpan(exampleRespMaskedpan)
+    r.SetScheme(exampleRespScheme)
+    r.SetSchemeId(exampleRespSchemeId)
+    r.SetSchemeLogo(exampleRespSchemeLogo)
+    r.SetSha256(exampleRespSha256)
+    r.SetTransStatus(exampleRespTransStatus)
+    r.SetTransno(exampleRespTransno)
+    return r
+}
+
+func TestNewAuthResponse(t *testing.T) {
+    model := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleRespMerchantid, model.GetMerchantid())
+    assert.Equal(t, exampleRespResult, model.GetResult())
+    assert.False(t, model.HasAmount())
+}
+
+func TestNewAuthResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewAuthResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetMerchantid())
+    assert.False(t, model.HasAmount())
+}
+
+func TestAuthResponseSetGetCycle(t *testing.T) {
+    model := openapiclient.NewAuthResponse(exampleRespMerchantid, exampleRespResult, exampleRespResultCode, exampleRespResultMessage)
+    model.SetAmount(exampleRespAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleRespAmount, model.GetAmount())
+
+    model.SetAtrn(exampleRespAtrn)
+    assert.True(t, model.HasAtrn())
+    assert.Equal(t, exampleRespAtrn, model.GetAtrn())
+
+    model.SetAtsd(exampleRespAtsd)
+    assert.True(t, model.HasAtsd())
+    assert.Equal(t, exampleRespAtsd, model.GetAtsd())
+
+    model.SetAuthcode(exampleRespAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleRespAuthcode, model.GetAuthcode())
+
+    model.SetAuthenResult(exampleRespAuthenResult)
+    assert.True(t, model.HasAuthenResult())
+    assert.Equal(t, exampleRespAuthenResult, model.GetAuthenResult())
+
+    model.SetAuthorised(exampleRespAuthorised)
+    assert.True(t, model.HasAuthorised())
+    assert.Equal(t, exampleRespAuthorised, model.GetAuthorised())
+
+    model.SetAvsResult(exampleRespAvsResult)
+    assert.True(t, model.HasAvsResult())
+    assert.Equal(t, exampleRespAvsResult, model.GetAvsResult())
+
+    model.SetBinCommercial(exampleRespBinCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleRespBinCommercial, model.GetBinCommercial())
+
+    model.SetBinDebit(exampleRespBinDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleRespBinDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleRespBinDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleRespBinDescription, model.GetBinDescription())
+
+    model.SetCavv(exampleRespCavv)
+    assert.True(t, model.HasCavv())
+    assert.Equal(t, exampleRespCavv, model.GetCavv())
+
+    model.SetContext(exampleRespContext)
+    assert.True(t, model.HasContext())
+    assert.Equal(t, exampleRespContext, model.GetContext())
+
+    model.SetCscResult(exampleRespCscResult)
+    assert.True(t, model.HasCscResult())
+    assert.Equal(t, exampleRespCscResult, model.GetCscResult())
+
+    model.SetCurrency(exampleRespCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleRespCurrency, model.GetCurrency())
+
+    model.SetDatetime(exampleRespDatetime)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleRespDatetime, model.GetDatetime())
+
+    model.SetEci(exampleRespEci)
+    assert.True(t, model.HasEci())
+    assert.Equal(t, exampleRespEci, model.GetEci())
+
+    model.SetIdentifier(exampleRespIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleRespIdentifier, model.GetIdentifier())
+
+    model.SetLive(exampleRespLive)
+    assert.True(t, model.HasLive())
+    assert.Equal(t, exampleRespLive, model.GetLive())
+
+    model.SetMaskedpan(exampleRespMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    assert.Equal(t, exampleRespMaskedpan, model.GetMaskedpan())
+
+    model.SetScheme(exampleRespScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleRespScheme, model.GetScheme())
+
+    model.SetSchemeId(exampleRespSchemeId)
+    assert.True(t, model.HasSchemeId())
+    assert.Equal(t, exampleRespSchemeId, model.GetSchemeId())
+
+    model.SetSchemeLogo(exampleRespSchemeLogo)
+    assert.True(t, model.HasSchemeLogo())
+    assert.Equal(t, exampleRespSchemeLogo, model.GetSchemeLogo())
+
+    model.SetSha256(exampleRespSha256)
+    assert.True(t, model.HasSha256())
+    assert.Equal(t, exampleRespSha256, model.GetSha256())
+
+    model.SetTransStatus(exampleRespTransStatus)
+    assert.True(t, model.HasTransStatus())
+    assert.Equal(t, exampleRespTransStatus, model.GetTransStatus())
+
+    model.SetTransno(exampleRespTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleRespTransno, model.GetTransno())
+}
+
+func TestAuthResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleAuthResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.AuthResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleRespResultCode, unmarshalled.GetResultCode())
+    assert.True(t, unmarshalled.HasAmount())
+}
+
+func TestAuthResponseToMap(t *testing.T) {
+    model := buildExampleAuthResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleRespAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "merchantid") {
+        assert.Equal(t, exampleRespMerchantid, m["merchantid"])
+    }
+}
+
+func TestNullableAuthResponseGetSet(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NullableAuthResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableAuthResponseUnset(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NewNullableAuthResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableAuthResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleAuthResponse()
+    n := openapiclient.NewNullableAuthResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableAuthResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleRespResultMessage, newN.Get().GetResultMessage())
+    }
+}
+

--- a/test/model/model_batch_report_request_test.go
+++ b/test/model/model_batch_report_request_test.go
@@ -1,0 +1,102 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBRRBatchId int32 = 99
+var exampleBRRClientAccountId = "clientA"
+
+func buildExampleBatchReportRequest() *openapiclient.BatchReportRequest {
+    r := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    r.SetClientAccountId(exampleBRRClientAccountId)
+    return r
+}
+
+func TestNewBatchReportRequest(t *testing.T) {
+    model := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBRRBatchId, model.GetBatchId())
+    assert.False(t, model.HasClientAccountId())
+}
+
+func TestNewBatchReportRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchReportRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetBatchId())
+}
+
+func TestBatchReportRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchReportRequest(exampleBRRBatchId)
+    model.SetClientAccountId(exampleBRRClientAccountId)
+    assert.True(t, model.HasClientAccountId())
+    assert.Equal(t, exampleBRRClientAccountId, model.GetClientAccountId())
+    val, ok := model.GetClientAccountIdOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBRRClientAccountId, *val)
+    }
+}
+
+func TestBatchReportRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchReportRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchReportRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBRRBatchId, unmarshalled.GetBatchId())
+    assert.True(t, unmarshalled.HasClientAccountId())
+    assert.Equal(t, exampleBRRClientAccountId, unmarshalled.GetClientAccountId())
+}
+
+func TestBatchReportRequestToMap(t *testing.T) {
+    model := buildExampleBatchReportRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_id") {
+        assert.Equal(t, exampleBRRBatchId, m["batch_id"])
+    }
+    if assert.Contains(t, m, "client_account_id") {
+        assert.Equal(t, &exampleBRRClientAccountId, m["client_account_id"])
+    }
+}
+
+func TestNullableBatchReportRequestGetSet(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NullableBatchReportRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchReportRequestUnset(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NewNullableBatchReportRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchReportRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchReportRequest()
+    n := openapiclient.NewNullableBatchReportRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchReportRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBRRClientAccountId, newN.Get().GetClientAccountId())
+    }
+}
+

--- a/test/model/model_batch_report_response_model_test.go
+++ b/test/model/model_batch_report_response_model_test.go
@@ -1,0 +1,153 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBRRAmount int32 = 1000
+var exampleBRRBatchDate = "2023-02-01T15:04:05Z"
+var exampleBRRBatchId int32 = 55
+var exampleBRRBatchStatus = "COMPLETE"
+var exampleBRRClientAccountId = "clientB"
+
+var exampleResAccountId = "acc123"
+var exampleResAmount int32 = 10
+var exampleResAuthcode = "AUTH1"
+var exampleResDatetime = time.Date(2023, time.March, 4, 5, 6, 7, 0, time.UTC)
+var exampleResIdentifier = "id99"
+var exampleResMaskedpan = "411111******1111"
+var exampleResMerchantid int32 = 77
+var exampleResMessage = "Approved"
+var exampleResResult int32 = 1
+var exampleResResultCode = "OK"
+var exampleResScheme = "VISA"
+var exampleResSchemeId = "VI"
+var exampleResSchemeLogo = "logo"
+var exampleResTransno int32 = 101
+
+func buildExampleBatchTransactionResult() openapiclient.BatchTransactionResultModel {
+    r := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    r.SetAmount(exampleResAmount)
+    r.SetAuthcode(exampleResAuthcode)
+    r.SetDatetime(exampleResDatetime)
+    r.SetMaskedpan(exampleResMaskedpan)
+    r.SetScheme(exampleResScheme)
+    r.SetSchemeId(exampleResSchemeId)
+    r.SetSchemeLogo(exampleResSchemeLogo)
+    r.SetTransno(exampleResTransno)
+    return *r
+}
+
+func buildExampleBatchReportResponseModel() *openapiclient.BatchReportResponseModel {
+    tr := buildExampleBatchTransactionResult()
+    m := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    return m
+}
+
+func TestNewBatchReportResponseModel(t *testing.T) {
+    tr := buildExampleBatchTransactionResult()
+    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBRRAmount, model.GetAmount())
+    assert.Equal(t, exampleBRRBatchDate, model.GetBatchDate())
+    assert.Equal(t, exampleBRRBatchId, model.GetBatchId())
+    assert.Equal(t, exampleBRRBatchStatus, model.GetBatchStatus())
+    assert.Equal(t, exampleBRRClientAccountId, model.GetClientAccountId())
+    assert.Equal(t, 1, len(model.GetTransactions()))
+}
+
+func TestNewBatchReportResponseModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchReportResponseModelWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+    assert.Equal(t, "", model.GetBatchDate())
+    assert.Equal(t, int32(0), model.GetBatchId())
+    assert.Equal(t, "", model.GetBatchStatus())
+    assert.Equal(t, "", model.GetClientAccountId())
+    assert.Equal(t, 0, len(model.GetTransactions()))
+}
+
+func TestBatchReportResponseModelSetGetCycle(t *testing.T) {
+    tr := buildExampleBatchTransactionResult()
+    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+    model.SetAmount(2000)
+    assert.Equal(t, int32(2000), model.GetAmount())
+    model.SetBatchDate("2024-01-01")
+    assert.Equal(t, "2024-01-01", model.GetBatchDate())
+    model.SetBatchId(66)
+    assert.Equal(t, int32(66), model.GetBatchId())
+    model.SetBatchStatus("QUEUED")
+    assert.Equal(t, "QUEUED", model.GetBatchStatus())
+    model.SetClientAccountId("other")
+    assert.Equal(t, "other", model.GetClientAccountId())
+    model.SetTransactions([]openapiclient.BatchTransactionResultModel{tr, tr})
+    assert.Equal(t, 2, len(model.GetTransactions()))
+}
+
+func TestBatchReportResponseModelJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchReportResponseModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchReportResponseModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBRRAmount, unmarshalled.GetAmount())
+    assert.Equal(t, exampleBRRBatchDate, unmarshalled.GetBatchDate())
+    assert.Equal(t, exampleBRRBatchStatus, unmarshalled.GetBatchStatus())
+    assert.Equal(t, 1, len(unmarshalled.GetTransactions()))
+}
+
+func TestBatchReportResponseModelToMap(t *testing.T) {
+    model := buildExampleBatchReportResponseModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleBRRAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "batch_status") {
+        assert.Equal(t, exampleBRRBatchStatus, m["batch_status"])
+    }
+    if assert.Contains(t, m, "transactions") {
+        assert.Equal(t, 1, len(m["transactions"].([]openapiclient.BatchTransactionResultModel)))
+    }
+}
+
+func TestNullableBatchReportResponseModelGetSet(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NullableBatchReportResponseModel{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchReportResponseModelUnset(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NewNullableBatchReportResponseModel(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchReportResponseModelJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchReportResponseModel()
+    n := openapiclient.NewNullableBatchReportResponseModel(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchReportResponseModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBRRBatchStatus, newN.Get().GetBatchStatus())
+    }
+}
+

--- a/test/model/model_batch_test.go
+++ b/test/model/model_batch_test.go
@@ -1,0 +1,106 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBatchDate = "2023-01-01"
+var exampleBatchId int32 = 42
+var exampleBatchStatus = "QUEUED"
+
+func buildExampleBatch() *openapiclient.Batch {
+    b := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    b.SetBatchId(exampleBatchId)
+    return b
+}
+
+func TestNewBatch(t *testing.T) {
+    model := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBatchDate, model.GetBatchDate())
+    assert.Equal(t, exampleBatchStatus, model.GetBatchStatus())
+    assert.False(t, model.HasBatchId())
+}
+
+func TestNewBatchWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetBatchDate())
+    assert.Equal(t, "", model.GetBatchStatus())
+}
+
+func TestBatchSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatch(exampleBatchDate, exampleBatchStatus)
+    model.SetBatchDate("2023-02-02")
+    assert.Equal(t, "2023-02-02", model.GetBatchDate())
+
+    model.SetBatchId(exampleBatchId)
+    assert.True(t, model.HasBatchId())
+    assert.Equal(t, exampleBatchId, model.GetBatchId())
+
+    model.SetBatchStatus("COMPLETE")
+    assert.Equal(t, "COMPLETE", model.GetBatchStatus())
+}
+
+func TestBatchJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatch()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Batch
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBatchDate, unmarshalled.GetBatchDate())
+    assert.True(t, unmarshalled.HasBatchId())
+    assert.Equal(t, exampleBatchId, unmarshalled.GetBatchId())
+}
+
+func TestBatchToMap(t *testing.T) {
+    model := buildExampleBatch()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_date") {
+        assert.Equal(t, exampleBatchDate, m["batch_date"])
+    }
+    if assert.Contains(t, m, "batch_status") {
+        assert.Equal(t, exampleBatchStatus, m["batch_status"])
+    }
+}
+
+func TestNullableBatchGetSet(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NullableBatch{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchUnset(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NewNullableBatch(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatch()
+    n := openapiclient.NewNullableBatch(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatch
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBatchStatus, newN.Get().GetBatchStatus())
+    }
+}
+

--- a/test/model/model_batch_transaction_report_request_test.go
+++ b/test/model/model_batch_transaction_report_request_test.go
@@ -1,0 +1,121 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTRRMaxResults int32 = 20
+var exampleBTRRNextToken = "token"
+var exampleBTRROrderBy = "trans_no"
+
+func buildExampleBatchTransactionReportRequest() *openapiclient.BatchTransactionReportRequest {
+    r := openapiclient.NewBatchTransactionReportRequest()
+    r.SetMaxResults(exampleBTRRMaxResults)
+    r.SetNextToken(exampleBTRRNextToken)
+    r.SetOrderBy(exampleBTRROrderBy)
+    return r
+}
+
+func TestNewBatchTransactionReportRequest(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasMaxResults())
+    assert.False(t, model.HasNextToken())
+    assert.False(t, model.HasOrderBy())
+}
+
+func TestNewBatchTransactionReportRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasMaxResults())
+    assert.False(t, model.HasNextToken())
+    assert.False(t, model.HasOrderBy())
+}
+
+func TestBatchTransactionReportRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportRequest()
+    model.SetMaxResults(exampleBTRRMaxResults)
+    assert.True(t, model.HasMaxResults())
+    assert.Equal(t, exampleBTRRMaxResults, model.GetMaxResults())
+    val, ok := model.GetMaxResultsOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTRRMaxResults, *val)
+    }
+    model.SetNextToken(exampleBTRRNextToken)
+    assert.True(t, model.HasNextToken())
+    assert.Equal(t, exampleBTRRNextToken, model.GetNextToken())
+    val2, ok2 := model.GetNextTokenOk()
+    require.True(t, ok2)
+    if assert.NotNil(t, val2) {
+        assert.Equal(t, exampleBTRRNextToken, *val2)
+    }
+    model.SetOrderBy(exampleBTRROrderBy)
+    assert.True(t, model.HasOrderBy())
+    assert.Equal(t, exampleBTRROrderBy, model.GetOrderBy())
+}
+
+func TestBatchTransactionReportRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionReportRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionReportRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasMaxResults())
+    assert.Equal(t, exampleBTRRNextToken, unmarshalled.GetNextToken())
+}
+
+func TestBatchTransactionReportRequestToMap(t *testing.T) {
+    model := buildExampleBatchTransactionReportRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "maxResults") {
+        assert.Equal(t, &exampleBTRRMaxResults, m["maxResults"])
+    }
+    if assert.Contains(t, m, "nextToken") {
+        assert.Equal(t, &exampleBTRRNextToken, m["nextToken"])
+    }
+    if assert.Contains(t, m, "orderBy") {
+        assert.Equal(t, &exampleBTRROrderBy, m["orderBy"])
+    }
+}
+
+func TestNullableBatchTransactionReportRequestGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NullableBatchTransactionReportRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionReportRequestUnset(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NewNullableBatchTransactionReportRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionReportRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionReportRequest()
+    n := openapiclient.NewNullableBatchTransactionReportRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionReportRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTRRNextToken, newN.Get().GetNextToken())
+    }
+}
+

--- a/test/model/model_batch_transaction_report_response_test.go
+++ b/test/model/model_batch_transaction_report_response_test.go
@@ -1,0 +1,124 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTRRespCount int32 = 1
+var exampleBTRRespMaxResults int32 = 10
+var exampleBTRRespNextToken = "next"
+
+var exampleAuthRefMerchant int32 = 10
+
+func buildExampleAuthReferenceSimple() openapiclient.AuthReference {
+    a := openapiclient.NewAuthReference()
+    a.SetAuthcode("AC")
+    a.SetMerchantid(exampleAuthRefMerchant)
+    return *a
+}
+
+func buildExampleBatchTransactionReportResponse() *openapiclient.BatchTransactionReportResponse {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    r := openapiclient.NewBatchTransactionReportResponse(data)
+    r.SetCount(exampleBTRRespCount)
+    r.SetMaxResults(exampleBTRRespMaxResults)
+    r.SetNextToken(exampleBTRRespNextToken)
+    return r
+}
+
+func TestNewBatchTransactionReportResponse(t *testing.T) {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    model := openapiclient.NewBatchTransactionReportResponse(data)
+    require.NotNil(t, model)
+    assert.Equal(t, 1, len(model.GetData()))
+    assert.False(t, model.HasCount())
+}
+
+func TestNewBatchTransactionReportResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionReportResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, 0, len(model.GetData()))
+}
+
+func TestBatchTransactionReportResponseSetGetCycle(t *testing.T) {
+    data := []openapiclient.AuthReference{buildExampleAuthReferenceSimple()}
+    model := openapiclient.NewBatchTransactionReportResponse(data)
+    model.SetCount(exampleBTRRespCount)
+    assert.True(t, model.HasCount())
+    assert.Equal(t, exampleBTRRespCount, model.GetCount())
+    val, ok := model.GetCountOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTRRespCount, *val)
+    }
+    model.SetMaxResults(exampleBTRRespMaxResults)
+    assert.True(t, model.HasMaxResults())
+    model.SetNextToken(exampleBTRRespNextToken)
+    assert.True(t, model.HasNextToken())
+}
+
+func TestBatchTransactionReportResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionReportResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionReportResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, 1, len(unmarshalled.GetData()))
+    assert.True(t, unmarshalled.HasCount())
+    assert.Equal(t, exampleBTRRespNextToken, unmarshalled.GetNextToken())
+}
+
+func TestBatchTransactionReportResponseToMap(t *testing.T) {
+    model := buildExampleBatchTransactionReportResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "data") {
+        assert.Equal(t, 1, len(m["data"].([]openapiclient.AuthReference)))
+    }
+    if assert.Contains(t, m, "count") {
+        assert.Equal(t, &exampleBTRRespCount, m["count"])
+    }
+    if assert.Contains(t, m, "nextToken") {
+        assert.Equal(t, &exampleBTRRespNextToken, m["nextToken"])
+    }
+}
+
+func TestNullableBatchTransactionReportResponseGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NullableBatchTransactionReportResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionReportResponseUnset(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NewNullableBatchTransactionReportResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionReportResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionReportResponse()
+    n := openapiclient.NewNullableBatchTransactionReportResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionReportResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTRRespCount, newN.Get().GetCount())
+    }
+}
+

--- a/test/model/model_batch_transaction_result_model_test.go
+++ b/test/model/model_batch_transaction_result_model_test.go
@@ -1,0 +1,152 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleResAccountId = "ac123"
+var exampleResAmount int32 = 10
+var exampleResAuthcode = "AUTH"
+var exampleResDatetime = time.Date(2023, time.January, 1, 2, 3, 4, 0, time.UTC)
+var exampleResIdentifier = "id001"
+var exampleResMaskedpan = "411111******1111"
+var exampleResMerchantid int32 = 44
+var exampleResMessage = "OK"
+var exampleResResult int32 = 1
+var exampleResResultCode = "A1"
+var exampleResScheme = "VISA"
+var exampleResSchemeId = "VI"
+var exampleResSchemeLogo = "logo"
+var exampleResTransno int32 = 99
+
+func buildExampleBatchTransactionResultModel() *openapiclient.BatchTransactionResultModel {
+    m := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    m.SetAmount(exampleResAmount)
+    m.SetAuthcode(exampleResAuthcode)
+    m.SetDatetime(exampleResDatetime)
+    m.SetMaskedpan(exampleResMaskedpan)
+    m.SetScheme(exampleResScheme)
+    m.SetSchemeId(exampleResSchemeId)
+    m.SetSchemeLogo(exampleResSchemeLogo)
+    m.SetTransno(exampleResTransno)
+    return m
+}
+
+func TestNewBatchTransactionResultModel(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleResAccountId, model.GetAccountId())
+    assert.Equal(t, exampleResIdentifier, model.GetIdentifier())
+    assert.Equal(t, exampleResMerchantid, model.GetMerchantid())
+    assert.Equal(t, exampleResMessage, model.GetMessage())
+    assert.Equal(t, exampleResResult, model.GetResult())
+    assert.Equal(t, exampleResResultCode, model.GetResultCode())
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasAuthcode())
+    assert.False(t, model.HasDatetime())
+    assert.False(t, model.HasMaskedpan())
+    assert.False(t, model.HasScheme())
+    assert.False(t, model.HasSchemeId())
+    assert.False(t, model.HasSchemeLogo())
+    assert.False(t, model.HasTransno())
+}
+
+func TestNewBatchTransactionResultModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModelWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+    assert.Equal(t, "", model.GetIdentifier())
+    assert.Equal(t, int32(0), model.GetMerchantid())
+    assert.Equal(t, "", model.GetMessage())
+    assert.Equal(t, int32(0), model.GetResult())
+    assert.Equal(t, "", model.GetResultCode())
+}
+
+func TestBatchTransactionResultModelSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
+    model.SetAmount(exampleResAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleResAmount, model.GetAmount())
+    model.SetAuthcode(exampleResAuthcode)
+    assert.True(t, model.HasAuthcode())
+    assert.Equal(t, exampleResAuthcode, model.GetAuthcode())
+    model.SetDatetime(exampleResDatetime)
+    assert.True(t, model.HasDatetime())
+    model.SetMaskedpan(exampleResMaskedpan)
+    assert.True(t, model.HasMaskedpan())
+    model.SetScheme(exampleResScheme)
+    assert.True(t, model.HasScheme())
+    model.SetSchemeId(exampleResSchemeId)
+    assert.True(t, model.HasSchemeId())
+    model.SetSchemeLogo(exampleResSchemeLogo)
+    assert.True(t, model.HasSchemeLogo())
+    model.SetTransno(exampleResTransno)
+    assert.True(t, model.HasTransno())
+}
+
+func TestBatchTransactionResultModelJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransactionResultModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransactionResultModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleResAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasAmount())
+    assert.Equal(t, exampleResTransno, unmarshalled.GetTransno())
+}
+
+func TestBatchTransactionResultModelToMap(t *testing.T) {
+    model := buildExampleBatchTransactionResultModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleResAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleResAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "scheme_id") {
+        assert.Equal(t, &exampleResSchemeId, m["scheme_id"])
+    }
+}
+
+func TestNullableBatchTransactionResultModelGetSet(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NullableBatchTransactionResultModel{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionResultModelUnset(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NewNullableBatchTransactionResultModel(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionResultModelJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransactionResultModel()
+    n := openapiclient.NewNullableBatchTransactionResultModel(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransactionResultModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleResAccountId, newN.Get().GetAccountId())
+    }
+}
+

--- a/test/model/model_batch_transaction_test.go
+++ b/test/model/model_batch_transaction_test.go
@@ -1,0 +1,119 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBTAccountId = "acc1"
+var exampleBTAmount int32 = 500
+var exampleBTIdentifier = "id1"
+var exampleBTMerchantId int32 = 42
+
+func buildExampleBatchTransaction() *openapiclient.BatchTransaction {
+    b := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    b.SetIdentifier(exampleBTIdentifier)
+    b.SetMerchantid(exampleBTMerchantId)
+    return b
+}
+
+func TestNewBatchTransaction(t *testing.T) {
+    model := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBTAccountId, model.GetAccountId())
+    assert.Equal(t, exampleBTAmount, model.GetAmount())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasMerchantid())
+}
+
+func TestNewBatchTransactionWithDefaults(t *testing.T) {
+    model := openapiclient.NewBatchTransactionWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+    assert.Equal(t, int32(0), model.GetAmount())
+}
+
+func TestBatchTransactionSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBatchTransaction(exampleBTAccountId, exampleBTAmount)
+    model.SetIdentifier(exampleBTIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleBTIdentifier, model.GetIdentifier())
+    val, ok := model.GetIdentifierOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleBTIdentifier, *val)
+    }
+    model.SetMerchantid(exampleBTMerchantId)
+    assert.True(t, model.HasMerchantid())
+    assert.Equal(t, exampleBTMerchantId, model.GetMerchantid())
+    val2, ok2 := model.GetMerchantidOk()
+    require.True(t, ok2)
+    if assert.NotNil(t, val2) {
+        assert.Equal(t, exampleBTMerchantId, *val2)
+    }
+}
+
+func TestBatchTransactionJSONRoundTrip(t *testing.T) {
+    model := buildExampleBatchTransaction()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BatchTransaction
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBTAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasIdentifier())
+    assert.Equal(t, exampleBTMerchantId, unmarshalled.GetMerchantid())
+}
+
+func TestBatchTransactionToMap(t *testing.T) {
+    model := buildExampleBatchTransaction()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleBTAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleBTAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, &exampleBTIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableBatchTransactionGetSet(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NullableBatchTransaction{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBatchTransactionUnset(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NewNullableBatchTransaction(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBatchTransactionJSONRoundTrip(t *testing.T) {
+    base := buildExampleBatchTransaction()
+    n := openapiclient.NewNullableBatchTransaction(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBatchTransaction
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBTIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_bin_lookup_test.go
+++ b/test/model/model_bin_lookup_test.go
@@ -1,0 +1,93 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBinLookup int32 = 123456
+
+func buildExampleBinLookup() *openapiclient.BinLookup {
+    b := openapiclient.NewBinLookup(exampleBinLookup)
+    return b
+}
+
+func TestNewBinLookup(t *testing.T) {
+    model := openapiclient.NewBinLookup(exampleBinLookup)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleBinLookup, model.GetBin())
+}
+
+func TestNewBinLookupWithDefaults(t *testing.T) {
+    model := openapiclient.NewBinLookupWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetBin())
+}
+
+func TestBinLookupSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBinLookup(exampleBinLookup)
+    model.SetBin(654321)
+    assert.Equal(t, int32(654321), model.GetBin())
+    val, ok := model.GetBinOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, int32(654321), *val)
+    }
+}
+
+func TestBinLookupJSONRoundTrip(t *testing.T) {
+    model := buildExampleBinLookup()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.BinLookup
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBinLookup, unmarshalled.GetBin())
+}
+
+func TestBinLookupToMap(t *testing.T) {
+    model := buildExampleBinLookup()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "bin") {
+        assert.Equal(t, exampleBinLookup, m["bin"])
+    }
+}
+
+func TestNullableBinLookupGetSet(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NullableBinLookup{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBinLookupUnset(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NewNullableBinLookup(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBinLookupJSONRoundTrip(t *testing.T) {
+    base := buildExampleBinLookup()
+    n := openapiclient.NewNullableBinLookup(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBinLookup
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBinLookup, newN.Get().GetBin())
+    }
+}
+

--- a/test/model/model_bin_test.go
+++ b/test/model/model_bin_test.go
@@ -1,0 +1,147 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleBinCommercial = true
+var exampleBinCorporate = true
+var exampleBinCountry = "GB"
+var exampleBinCredit = true
+var exampleBinCurrency = "GBP"
+var exampleBinDebit = true
+var exampleBinDescription = "Business"
+var exampleBinEu = true
+var exampleBinScheme = "VISA"
+
+func buildExampleBin() *openapiclient.Bin {
+    b := openapiclient.NewBin()
+    b.SetBinCommercial(exampleBinCommercial)
+    b.SetBinCorporate(exampleBinCorporate)
+    b.SetBinCountryIssued(exampleBinCountry)
+    b.SetBinCredit(exampleBinCredit)
+    b.SetBinCurrency(exampleBinCurrency)
+    b.SetBinDebit(exampleBinDebit)
+    b.SetBinDescription(exampleBinDescription)
+    b.SetBinEu(exampleBinEu)
+    b.SetScheme(exampleBinScheme)
+    return b
+}
+
+func TestNewBin(t *testing.T) {
+    model := openapiclient.NewBin()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBinCommercial())
+    assert.False(t, model.HasScheme())
+}
+
+func TestNewBinWithDefaults(t *testing.T) {
+    model := openapiclient.NewBinWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBinDebit())
+}
+
+func TestBinSetGetCycle(t *testing.T) {
+    model := openapiclient.NewBin()
+    model.SetBinCommercial(exampleBinCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleBinCommercial, model.GetBinCommercial())
+    if val, ok := model.GetBinCommercialOk(); assert.True(t, ok) {
+        assert.NotNil(t, val)
+        assert.Equal(t, exampleBinCommercial, *val)
+    }
+
+    model.SetBinCorporate(exampleBinCorporate)
+    assert.True(t, model.HasBinCorporate())
+    assert.Equal(t, exampleBinCorporate, model.GetBinCorporate())
+
+    model.SetBinCountryIssued(exampleBinCountry)
+    assert.True(t, model.HasBinCountryIssued())
+    assert.Equal(t, exampleBinCountry, model.GetBinCountryIssued())
+
+    model.SetBinCredit(exampleBinCredit)
+    assert.True(t, model.HasBinCredit())
+    assert.Equal(t, exampleBinCredit, model.GetBinCredit())
+
+    model.SetBinCurrency(exampleBinCurrency)
+    assert.True(t, model.HasBinCurrency())
+    assert.Equal(t, exampleBinCurrency, model.GetBinCurrency())
+
+    model.SetBinDebit(exampleBinDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleBinDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleBinDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleBinDescription, model.GetBinDescription())
+
+    model.SetBinEu(exampleBinEu)
+    assert.True(t, model.HasBinEu())
+    assert.Equal(t, exampleBinEu, model.GetBinEu())
+
+    model.SetScheme(exampleBinScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleBinScheme, model.GetScheme())
+}
+
+func TestBinJSONRoundTrip(t *testing.T) {
+    model := buildExampleBin()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Bin
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleBinCommercial, unmarshalled.GetBinCommercial())
+    assert.Equal(t, exampleBinScheme, unmarshalled.GetScheme())
+}
+
+func TestBinToMap(t *testing.T) {
+    model := buildExampleBin()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "bin_commercial") {
+        assert.Equal(t, &exampleBinCommercial, m["bin_commercial"])
+    }
+    if assert.Contains(t, m, "scheme") {
+        assert.Equal(t, &exampleBinScheme, m["scheme"])
+    }
+}
+
+func TestNullableBinGetSet(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NullableBin{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableBinUnset(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NewNullableBin(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableBinJSONRoundTrip(t *testing.T) {
+    base := buildExampleBin()
+    n := openapiclient.NewNullableBin(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableBin
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleBinScheme, newN.Get().GetScheme())
+    }
+}
+

--- a/test/model/model_c_res_auth_request_test.go
+++ b/test/model/model_c_res_auth_request_test.go
@@ -1,0 +1,95 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCRes = "cresdata"
+
+func buildExampleCResAuthRequest() *openapiclient.CResAuthRequest {
+    c := openapiclient.NewCResAuthRequest()
+    c.SetCres(exampleCRes)
+    return c
+}
+
+func TestNewCResAuthRequest(t *testing.T) {
+    model := openapiclient.NewCResAuthRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCres())
+}
+
+func TestNewCResAuthRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewCResAuthRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCres())
+}
+
+func TestCResAuthRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCResAuthRequest()
+    model.SetCres(exampleCRes)
+    assert.True(t, model.HasCres())
+    assert.Equal(t, exampleCRes, model.GetCres())
+    val, ok := model.GetCresOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleCRes, *val)
+    }
+}
+
+func TestCResAuthRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleCResAuthRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CResAuthRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCRes, unmarshalled.GetCres())
+}
+
+func TestCResAuthRequestToMap(t *testing.T) {
+    model := buildExampleCResAuthRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "cres") {
+        assert.Equal(t, &exampleCRes, m["cres"])
+    }
+}
+
+func TestNullableCResAuthRequestGetSet(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NullableCResAuthRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCResAuthRequestUnset(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NewNullableCResAuthRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCResAuthRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleCResAuthRequest()
+    n := openapiclient.NewNullableCResAuthRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCResAuthRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCRes, newN.Get().GetCres())
+    }
+}
+

--- a/test/model/model_capture_request_test.go
+++ b/test/model/model_capture_request_test.go
@@ -1,0 +1,119 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCaptureAmount int32 = 5000
+var exampleCaptureIdentifier = "CAPID"
+var exampleCaptureMerchantID int32 = 321
+var exampleCaptureTransno int32 = 42
+
+func buildExampleCaptureRequest() *openapiclient.CaptureRequest {
+    c := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    c.SetAirlineData(*buildExampleAdvice())
+    c.SetAmount(exampleCaptureAmount)
+    c.SetEventManagement(buildExampleEventData())
+    c.SetIdentifier(exampleCaptureIdentifier)
+    c.SetTransno(exampleCaptureTransno)
+    return c
+}
+
+func TestNewCaptureRequest(t *testing.T) {
+    model := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCaptureMerchantID, model.GetMerchantid())
+    assert.False(t, model.HasAmount())
+}
+
+func TestNewCaptureRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewCaptureRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestCaptureRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCaptureRequest(exampleCaptureMerchantID)
+    model.SetAirlineData(*buildExampleAdvice())
+    assert.True(t, model.HasAirlineData())
+
+    model.SetAmount(exampleCaptureAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleCaptureAmount, model.GetAmount())
+
+    model.SetEventManagement(buildExampleEventData())
+    assert.True(t, model.HasEventManagement())
+
+    model.SetIdentifier(exampleCaptureIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleCaptureIdentifier, model.GetIdentifier())
+
+    model.SetMerchantid(exampleCaptureMerchantID)
+    assert.Equal(t, exampleCaptureMerchantID, model.GetMerchantid())
+
+    model.SetTransno(exampleCaptureTransno)
+    assert.True(t, model.HasTransno())
+    assert.Equal(t, exampleCaptureTransno, model.GetTransno())
+}
+
+func TestCaptureRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleCaptureRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CaptureRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCaptureMerchantID, unmarshalled.GetMerchantid())
+    assert.True(t, unmarshalled.HasIdentifier())
+}
+
+func TestCaptureRequestToMap(t *testing.T) {
+    model := buildExampleCaptureRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "merchantid") {
+        assert.Equal(t, exampleCaptureMerchantID, m["merchantid"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, &exampleCaptureIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableCaptureRequestGetSet(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NullableCaptureRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCaptureRequestUnset(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NewNullableCaptureRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCaptureRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleCaptureRequest()
+    n := openapiclient.NewNullableCaptureRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCaptureRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCaptureIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_card_holder_account_test.go
+++ b/test/model/model_card_holder_account_test.go
@@ -1,0 +1,138 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCHAAccountId = "acc123"
+var exampleCHADateCreated = time.Date(2023, time.February, 1, 9, 0, 0, 0, time.UTC)
+var exampleCHADefaultCardId = "cardA"
+var exampleCHADefaultCardIndex int32 = 0
+var exampleCHALastModified = time.Date(2023, time.March, 1, 10, 0, 0, 0, time.UTC)
+var exampleCHAStatus = "ACTIVE"
+var exampleCHAUniqueId = "unique1"
+
+func buildExampleCardHolderAccount() *openapiclient.CardHolderAccount {
+    c := openapiclient.NewCardHolderAccount(exampleCHAAccountId, buildExampleContact())
+    c.SetCards([]openapiclient.Card{*buildExampleCard()})
+    c.SetDateCreated(exampleCHADateCreated)
+    c.SetDefaultCardId(exampleCHADefaultCardId)
+    c.SetDefaultCardIndex(exampleCHADefaultCardIndex)
+    c.SetLastModified(exampleCHALastModified)
+    c.SetStatus(exampleCHAStatus)
+    c.SetUniqueId(exampleCHAUniqueId)
+    return c
+}
+
+func TestNewCardHolderAccount(t *testing.T) {
+    contact := buildExampleContact()
+    model := openapiclient.NewCardHolderAccount(exampleCHAAccountId, contact)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCHAAccountId, model.GetAccountId())
+    assert.Equal(t, contact, model.GetContact())
+    assert.False(t, model.HasCards())
+}
+
+func TestNewCardHolderAccountWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardHolderAccountWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, "", model.GetAccountId())
+}
+
+func TestCardHolderAccountSetGetCycle(t *testing.T) {
+    contact := buildExampleContact()
+    model := openapiclient.NewCardHolderAccount(exampleCHAAccountId, contact)
+    model.SetCards([]openapiclient.Card{*buildExampleCard()})
+    assert.True(t, model.HasCards())
+    assert.Equal(t, 1, len(model.GetCards()))
+
+    model.SetContact(contact)
+    assert.Equal(t, contact, model.GetContact())
+
+    model.SetDateCreated(exampleCHADateCreated)
+    assert.True(t, model.HasDateCreated())
+    assert.Equal(t, exampleCHADateCreated, model.GetDateCreated())
+
+    model.SetDefaultCardId(exampleCHADefaultCardId)
+    assert.True(t, model.HasDefaultCardId())
+    assert.Equal(t, exampleCHADefaultCardId, model.GetDefaultCardId())
+
+    model.SetDefaultCardIndex(exampleCHADefaultCardIndex)
+    assert.True(t, model.HasDefaultCardIndex())
+    assert.Equal(t, exampleCHADefaultCardIndex, model.GetDefaultCardIndex())
+
+    model.SetLastModified(exampleCHALastModified)
+    assert.True(t, model.HasLastModified())
+    assert.Equal(t, exampleCHALastModified, model.GetLastModified())
+
+    model.SetStatus(exampleCHAStatus)
+    assert.True(t, model.HasStatus())
+    assert.Equal(t, exampleCHAStatus, model.GetStatus())
+
+    model.SetUniqueId(exampleCHAUniqueId)
+    assert.True(t, model.HasUniqueId())
+    assert.Equal(t, exampleCHAUniqueId, model.GetUniqueId())
+}
+
+func TestCardHolderAccountJSONRoundTrip(t *testing.T) {
+    model := buildExampleCardHolderAccount()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CardHolderAccount
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCHAAccountId, unmarshalled.GetAccountId())
+    assert.True(t, unmarshalled.HasStatus())
+}
+
+func TestCardHolderAccountToMap(t *testing.T) {
+    model := buildExampleCardHolderAccount()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "account_id") {
+        assert.Equal(t, exampleCHAAccountId, m["account_id"])
+    }
+    if assert.Contains(t, m, "default_card_id") {
+        assert.Equal(t, &exampleCHADefaultCardId, m["default_card_id"])
+    }
+}
+
+func TestNullableCardHolderAccountGetSet(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NullableCardHolderAccount{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardHolderAccountUnset(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NewNullableCardHolderAccount(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardHolderAccountJSONRoundTrip(t *testing.T) {
+    base := buildExampleCardHolderAccount()
+    n := openapiclient.NewNullableCardHolderAccount(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCardHolderAccount
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCHAUniqueId, newN.Get().GetUniqueId())
+    }
+}
+

--- a/test/model/model_card_status_test.go
+++ b/test/model/model_card_status_test.go
@@ -1,0 +1,101 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCardStatusValue = "ACTIVE"
+var exampleCardStatusDefault = true
+
+func buildExampleCardStatus() *openapiclient.CardStatus {
+    c := openapiclient.NewCardStatus()
+    c.SetCardStatus(exampleCardStatusValue)
+    c.SetDefault(exampleCardStatusDefault)
+    return c
+}
+
+func TestNewCardStatus(t *testing.T) {
+    model := openapiclient.NewCardStatus()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+    assert.False(t, model.HasDefault())
+}
+
+func TestNewCardStatusWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardStatusWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+}
+
+func TestCardStatusSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCardStatus()
+    model.SetCardStatus(exampleCardStatusValue)
+    assert.True(t, model.HasCardStatus())
+    assert.Equal(t, exampleCardStatusValue, model.GetCardStatus())
+
+    model.SetDefault(exampleCardStatusDefault)
+    assert.True(t, model.HasDefault())
+    assert.Equal(t, exampleCardStatusDefault, model.GetDefault())
+}
+
+func TestCardStatusJSONRoundTrip(t *testing.T) {
+    model := buildExampleCardStatus()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CardStatus
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCardStatusValue, unmarshalled.GetCardStatus())
+    assert.True(t, unmarshalled.GetDefault())
+}
+
+func TestCardStatusToMap(t *testing.T) {
+    model := buildExampleCardStatus()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "card_status") {
+        assert.Equal(t, &exampleCardStatusValue, m["card_status"])
+    }
+    if assert.Contains(t, m, "default") {
+        assert.Equal(t, &exampleCardStatusDefault, m["default"])
+    }
+}
+
+func TestNullableCardStatusGetSet(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NullableCardStatus{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardStatusUnset(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NewNullableCardStatus(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardStatusJSONRoundTrip(t *testing.T) {
+    base := buildExampleCardStatus()
+    n := openapiclient.NewNullableCardStatus(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCardStatus
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCardStatusValue, newN.Get().GetCardStatus())
+    }
+}
+

--- a/test/model/model_card_test.go
+++ b/test/model/model_card_test.go
@@ -1,0 +1,209 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+    "time"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCardCommercial = true
+var exampleCardCorporate = true
+var exampleCardCountry = "US"
+var exampleCardCredit = true
+var exampleCardCurrency = "USD"
+var exampleCardDebit = true
+var exampleCardDescription = "Gold"
+var exampleCardEu = false
+var exampleCardId = "card1"
+var exampleCardStatus = "ACTIVE"
+var exampleCardDate = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+var exampleCardDefault = true
+var exampleCardExpMonth int32 = 12
+var exampleCardExpYear int32 = 30
+var exampleCardLabel = "Main"
+var exampleCardLabel2 = "Main 12/30"
+var exampleCardLast4 = "1234"
+var exampleCardName = "John Smith"
+var exampleCardScheme = "VISA"
+var exampleCardToken = "tok123"
+
+func buildExampleCard() *openapiclient.Card {
+    c := openapiclient.NewCard()
+    c.SetBinCommercial(exampleCardCommercial)
+    c.SetBinCorporate(exampleCardCorporate)
+    c.SetBinCountryIssued(exampleCardCountry)
+    c.SetBinCredit(exampleCardCredit)
+    c.SetBinCurrency(exampleCardCurrency)
+    c.SetBinDebit(exampleCardDebit)
+    c.SetBinDescription(exampleCardDescription)
+    c.SetBinEu(exampleCardEu)
+    c.SetCardId(exampleCardId)
+    c.SetCardStatus(exampleCardStatus)
+    c.SetDateCreated(exampleCardDate)
+    c.SetDefault(exampleCardDefault)
+    c.SetExpmonth(exampleCardExpMonth)
+    c.SetExpyear(exampleCardExpYear)
+    c.SetLabel(exampleCardLabel)
+    c.SetLabel2(exampleCardLabel2)
+    c.SetLast4digits(exampleCardLast4)
+    c.SetNameOnCard(exampleCardName)
+    c.SetScheme(exampleCardScheme)
+    c.SetToken(exampleCardToken)
+    return c
+}
+
+func TestNewCard(t *testing.T) {
+    model := openapiclient.NewCard()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardId())
+}
+
+func TestNewCardWithDefaults(t *testing.T) {
+    model := openapiclient.NewCardWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCardStatus())
+}
+
+func TestCardSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCard()
+    model.SetBinCommercial(exampleCardCommercial)
+    assert.True(t, model.HasBinCommercial())
+    assert.Equal(t, exampleCardCommercial, model.GetBinCommercial())
+
+    model.SetBinCorporate(exampleCardCorporate)
+    assert.True(t, model.HasBinCorporate())
+    assert.Equal(t, exampleCardCorporate, model.GetBinCorporate())
+
+    model.SetBinCountryIssued(exampleCardCountry)
+    assert.True(t, model.HasBinCountryIssued())
+    assert.Equal(t, exampleCardCountry, model.GetBinCountryIssued())
+
+    model.SetBinCredit(exampleCardCredit)
+    assert.True(t, model.HasBinCredit())
+    assert.Equal(t, exampleCardCredit, model.GetBinCredit())
+
+    model.SetBinCurrency(exampleCardCurrency)
+    assert.True(t, model.HasBinCurrency())
+    assert.Equal(t, exampleCardCurrency, model.GetBinCurrency())
+
+    model.SetBinDebit(exampleCardDebit)
+    assert.True(t, model.HasBinDebit())
+    assert.Equal(t, exampleCardDebit, model.GetBinDebit())
+
+    model.SetBinDescription(exampleCardDescription)
+    assert.True(t, model.HasBinDescription())
+    assert.Equal(t, exampleCardDescription, model.GetBinDescription())
+
+    model.SetBinEu(exampleCardEu)
+    assert.True(t, model.HasBinEu())
+    assert.Equal(t, exampleCardEu, model.GetBinEu())
+
+    model.SetCardId(exampleCardId)
+    assert.True(t, model.HasCardId())
+    assert.Equal(t, exampleCardId, model.GetCardId())
+
+    model.SetCardStatus(exampleCardStatus)
+    assert.True(t, model.HasCardStatus())
+    assert.Equal(t, exampleCardStatus, model.GetCardStatus())
+
+    model.SetDateCreated(exampleCardDate)
+    assert.True(t, model.HasDateCreated())
+    assert.Equal(t, exampleCardDate, model.GetDateCreated())
+
+    model.SetDefault(exampleCardDefault)
+    assert.True(t, model.HasDefault())
+    assert.Equal(t, exampleCardDefault, model.GetDefault())
+
+    model.SetExpmonth(exampleCardExpMonth)
+    assert.True(t, model.HasExpmonth())
+    assert.Equal(t, exampleCardExpMonth, model.GetExpmonth())
+
+    model.SetExpyear(exampleCardExpYear)
+    assert.True(t, model.HasExpyear())
+    assert.Equal(t, exampleCardExpYear, model.GetExpyear())
+
+    model.SetLabel(exampleCardLabel)
+    assert.True(t, model.HasLabel())
+    assert.Equal(t, exampleCardLabel, model.GetLabel())
+
+    model.SetLabel2(exampleCardLabel2)
+    assert.True(t, model.HasLabel2())
+    assert.Equal(t, exampleCardLabel2, model.GetLabel2())
+
+    model.SetLast4digits(exampleCardLast4)
+    assert.True(t, model.HasLast4digits())
+    assert.Equal(t, exampleCardLast4, model.GetLast4digits())
+
+    model.SetNameOnCard(exampleCardName)
+    assert.True(t, model.HasNameOnCard())
+    assert.Equal(t, exampleCardName, model.GetNameOnCard())
+
+    model.SetScheme(exampleCardScheme)
+    assert.True(t, model.HasScheme())
+    assert.Equal(t, exampleCardScheme, model.GetScheme())
+
+    model.SetToken(exampleCardToken)
+    assert.True(t, model.HasToken())
+    assert.Equal(t, exampleCardToken, model.GetToken())
+}
+
+func TestCardJSONRoundTrip(t *testing.T) {
+    model := buildExampleCard()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.Card
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCardId, unmarshalled.GetCardId())
+    assert.Equal(t, exampleCardScheme, unmarshalled.GetScheme())
+}
+
+func TestCardToMap(t *testing.T) {
+    model := buildExampleCard()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "card_id") {
+        assert.Equal(t, &exampleCardId, m["card_id"])
+    }
+    if assert.Contains(t, m, "scheme") {
+        assert.Equal(t, &exampleCardScheme, m["scheme"])
+    }
+}
+
+func TestNullableCardGetSet(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NullableCard{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCardUnset(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NewNullableCard(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCardJSONRoundTrip(t *testing.T) {
+    base := buildExampleCard()
+    n := openapiclient.NewNullableCard(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCard
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCardId, newN.Get().GetCardId())
+    }
+}
+

--- a/test/model/model_charge_request_test.go
+++ b/test/model/model_charge_request_test.go
@@ -1,0 +1,166 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleChargeAmount int32 = 1000
+var exampleChargeAvsPolicy = "1"
+var exampleChargeAgreement = "agr"
+var exampleChargeCsc = "123"
+var exampleChargeCscPolicy = "2"
+var exampleChargeCurrency = "GBP"
+var exampleChargeDuplicate = "1"
+var exampleChargeIdentifier = "ID123"
+var exampleChargeInitiation = "M"
+var exampleChargeMatchAvsa = "Y"
+var exampleChargeMerchantID int32 = 55
+var exampleChargeTag = []string{"t1", "t2"}
+var exampleChargeToken = "tok"
+var exampleChargeTransInfo = "info"
+var exampleChargeTransType = "SALE"
+
+func buildExampleChargeRequest() *openapiclient.ChargeRequest {
+    c := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    c.SetAvsPostcodePolicy(exampleChargeAvsPolicy)
+    c.SetCardholderAgreement(exampleChargeAgreement)
+    c.SetCsc(exampleChargeCsc)
+    c.SetCscPolicy(exampleChargeCscPolicy)
+    c.SetCurrency(exampleChargeCurrency)
+    c.SetDuplicatePolicy(exampleChargeDuplicate)
+    c.SetInitiation(exampleChargeInitiation)
+    c.SetMatchAvsa(exampleChargeMatchAvsa)
+    c.SetTag(exampleChargeTag)
+    c.SetThreedsecure(buildExampleThreeDSecure())
+    c.SetTransInfo(exampleChargeTransInfo)
+    c.SetTransType(exampleChargeTransType)
+    return c
+}
+
+func TestNewChargeRequest(t *testing.T) {
+    model := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleChargeAmount, model.GetAmount())
+    assert.Equal(t, exampleChargeIdentifier, model.GetIdentifier())
+    assert.Equal(t, exampleChargeMerchantID, model.GetMerchantid())
+    assert.Equal(t, exampleChargeToken, model.GetToken())
+    assert.False(t, model.HasAvsPostcodePolicy())
+}
+
+func TestNewChargeRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewChargeRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.Equal(t, int32(0), model.GetAmount())
+}
+
+func TestChargeRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewChargeRequest(exampleChargeAmount, exampleChargeIdentifier, exampleChargeMerchantID, exampleChargeToken)
+    model.SetAvsPostcodePolicy(exampleChargeAvsPolicy)
+    assert.True(t, model.HasAvsPostcodePolicy())
+    assert.Equal(t, exampleChargeAvsPolicy, model.GetAvsPostcodePolicy())
+
+    model.SetCardholderAgreement(exampleChargeAgreement)
+    assert.True(t, model.HasCardholderAgreement())
+    assert.Equal(t, exampleChargeAgreement, model.GetCardholderAgreement())
+
+    model.SetCsc(exampleChargeCsc)
+    assert.True(t, model.HasCsc())
+    assert.Equal(t, exampleChargeCsc, model.GetCsc())
+
+    model.SetCscPolicy(exampleChargeCscPolicy)
+    assert.True(t, model.HasCscPolicy())
+    assert.Equal(t, exampleChargeCscPolicy, model.GetCscPolicy())
+
+    model.SetCurrency(exampleChargeCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleChargeCurrency, model.GetCurrency())
+
+    model.SetDuplicatePolicy(exampleChargeDuplicate)
+    assert.True(t, model.HasDuplicatePolicy())
+    assert.Equal(t, exampleChargeDuplicate, model.GetDuplicatePolicy())
+
+    model.SetInitiation(exampleChargeInitiation)
+    assert.True(t, model.HasInitiation())
+    assert.Equal(t, exampleChargeInitiation, model.GetInitiation())
+
+    model.SetMatchAvsa(exampleChargeMatchAvsa)
+    assert.True(t, model.HasMatchAvsa())
+    assert.Equal(t, exampleChargeMatchAvsa, model.GetMatchAvsa())
+
+    model.SetTag(exampleChargeTag)
+    assert.True(t, model.HasTag())
+    assert.Equal(t, exampleChargeTag, model.GetTag())
+
+    model.SetThreedsecure(buildExampleThreeDSecure())
+    assert.True(t, model.HasThreedsecure())
+
+    model.SetTransInfo(exampleChargeTransInfo)
+    assert.True(t, model.HasTransInfo())
+    assert.Equal(t, exampleChargeTransInfo, model.GetTransInfo())
+
+    model.SetTransType(exampleChargeTransType)
+    assert.True(t, model.HasTransType())
+    assert.Equal(t, exampleChargeTransType, model.GetTransType())
+}
+
+func TestChargeRequestJSONRoundTrip(t *testing.T) {
+    model := buildExampleChargeRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.ChargeRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleChargeToken, unmarshalled.GetToken())
+    assert.True(t, unmarshalled.HasTransType())
+}
+
+func TestChargeRequestToMap(t *testing.T) {
+    model := buildExampleChargeRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, exampleChargeAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, exampleChargeIdentifier, m["identifier"])
+    }
+}
+
+func TestNullableChargeRequestGetSet(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NullableChargeRequest{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableChargeRequestUnset(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NewNullableChargeRequest(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableChargeRequestJSONRoundTrip(t *testing.T) {
+    base := buildExampleChargeRequest()
+    n := openapiclient.NewNullableChargeRequest(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableChargeRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleChargeIdentifier, newN.Get().GetIdentifier())
+    }
+}
+

--- a/test/model/model_check_batch_status_response_test.go
+++ b/test/model/model_check_batch_status_response_test.go
@@ -1,0 +1,89 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func buildExampleCheckBatchStatusResponse() *openapiclient.CheckBatchStatusResponse {
+    c := openapiclient.NewCheckBatchStatusResponse()
+    c.SetBatches([]openapiclient.Batch{*buildExampleBatch()})
+    return c
+}
+
+func TestNewCheckBatchStatusResponse(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponse()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBatches())
+}
+
+func TestNewCheckBatchStatusResponseWithDefaults(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponseWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasBatches())
+}
+
+func TestCheckBatchStatusResponseSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusResponse()
+    model.SetBatches([]openapiclient.Batch{*buildExampleBatch()})
+    assert.True(t, model.HasBatches())
+    assert.Equal(t, 1, len(model.GetBatches()))
+}
+
+func TestCheckBatchStatusResponseJSONRoundTrip(t *testing.T) {
+    model := buildExampleCheckBatchStatusResponse()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CheckBatchStatusResponse
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasBatches())
+    assert.Equal(t, 1, len(unmarshalled.GetBatches()))
+}
+
+func TestCheckBatchStatusResponseToMap(t *testing.T) {
+    model := buildExampleCheckBatchStatusResponse()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batches") {
+        assert.NotNil(t, m["batches"])
+    }
+}
+
+func TestNullableCheckBatchStatusResponseGetSet(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NullableCheckBatchStatusResponse{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCheckBatchStatusResponseUnset(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NewNullableCheckBatchStatusResponse(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCheckBatchStatusResponseJSONRoundTrip(t *testing.T) {
+    base := buildExampleCheckBatchStatusResponse()
+    n := openapiclient.NewNullableCheckBatchStatusResponse(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCheckBatchStatusResponse
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, 1, len(newN.Get().GetBatches()))
+    }
+}
+

--- a/test/model/model_check_batch_status_test.go
+++ b/test/model/model_check_batch_status_test.go
@@ -1,0 +1,101 @@
+package citypay
+
+import (
+    "encoding/json"
+    "testing"
+
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var exampleCBSBatchIds = []int32{1, 2}
+var exampleCBSClientAccount = "client1"
+
+func buildExampleCheckBatchStatus() *openapiclient.CheckBatchStatus {
+    c := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    c.SetClientAccountId(exampleCBSClientAccount)
+    return c
+}
+
+func TestNewCheckBatchStatus(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleCBSBatchIds, model.GetBatchId())
+    assert.False(t, model.HasClientAccountId())
+}
+
+func TestNewCheckBatchStatusWithDefaults(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatusWithDefaults()
+    require.NotNil(t, model)
+    assert.Len(t, model.GetBatchId(), 0)
+}
+
+func TestCheckBatchStatusSetGetCycle(t *testing.T) {
+    model := openapiclient.NewCheckBatchStatus(exampleCBSBatchIds)
+    model.SetClientAccountId(exampleCBSClientAccount)
+    assert.True(t, model.HasClientAccountId())
+    assert.Equal(t, exampleCBSClientAccount, model.GetClientAccountId())
+    val, ok := model.GetClientAccountIdOk()
+    require.True(t, ok)
+    if assert.NotNil(t, val) {
+        assert.Equal(t, exampleCBSClientAccount, *val)
+    }
+}
+
+func TestCheckBatchStatusJSONRoundTrip(t *testing.T) {
+    model := buildExampleCheckBatchStatus()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.CheckBatchStatus
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleCBSClientAccount, unmarshalled.GetClientAccountId())
+    assert.Equal(t, exampleCBSBatchIds, unmarshalled.GetBatchId())
+}
+
+func TestCheckBatchStatusToMap(t *testing.T) {
+    model := buildExampleCheckBatchStatus()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "batch_id") {
+        assert.Equal(t, exampleCBSBatchIds, m["batch_id"])
+    }
+    if assert.Contains(t, m, "client_account_id") {
+        assert.Equal(t, &exampleCBSClientAccount, m["client_account_id"])
+    }
+}
+
+func TestNullableCheckBatchStatusGetSet(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NullableCheckBatchStatus{}
+    n.Set(base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, base, n.Get())
+}
+
+func TestNullableCheckBatchStatusUnset(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NewNullableCheckBatchStatus(base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullableCheckBatchStatusJSONRoundTrip(t *testing.T) {
+    base := buildExampleCheckBatchStatus()
+    n := openapiclient.NewNullableCheckBatchStatus(base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullableCheckBatchStatus
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCBSClientAccount, newN.Get().GetClientAccountId())
+    }
+}
+

--- a/test/model/model_contact_details_test.go
+++ b/test/model/model_contact_details_test.go
@@ -1,0 +1,170 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAddress1 = "1 Test Way"
+var exampleAddress2 = "Suite 5"
+var exampleAddress3 = "Floor 3"
+var exampleArea = "Test City"
+var exampleCompany = "Test Co"
+var exampleCountry = "GB"
+var exampleEmail = "contact@example.com"
+var exampleFirstname = "Jane"
+var exampleLastname = "Doe"
+var exampleMobile = "07123456789"
+var examplePostcode = "TE5 7ST"
+var exampleTelephone = "01111111111"
+var exampleTitle = "Ms"
+
+func buildExampleContactDetails() *openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1(exampleAddress1)
+	c.SetAddress2(exampleAddress2)
+	c.SetAddress3(exampleAddress3)
+	c.SetArea(exampleArea)
+	c.SetCompany(exampleCompany)
+	c.SetCountry(exampleCountry)
+	c.SetEmail(exampleEmail)
+	c.SetFirstname(exampleFirstname)
+	c.SetLastname(exampleLastname)
+	c.SetMobileNo(exampleMobile)
+	c.SetPostcode(examplePostcode)
+	c.SetTelephoneNo(exampleTelephone)
+	c.SetTitle(exampleTitle)
+	return c
+}
+
+func TestNewContactDetails(t *testing.T) {
+	model := openapiclient.NewContactDetails()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.False(t, model.HasCountry())
+}
+
+func TestNewContactDetailsWithDefaults(t *testing.T) {
+	model := openapiclient.NewContactDetailsWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.Equal(t, "", model.GetAddress1())
+}
+
+func TestContactDetailsSetGetCycle(t *testing.T) {
+	model := openapiclient.NewContactDetails()
+	model.SetAddress1(exampleAddress1)
+	assert.True(t, model.HasAddress1())
+	assert.Equal(t, exampleAddress1, model.GetAddress1())
+	if val, ok := model.GetAddress1Ok(); assert.True(t, ok) {
+		assert.Equal(t, exampleAddress1, *val)
+	}
+
+	model.SetAddress2(exampleAddress2)
+	assert.True(t, model.HasAddress2())
+	assert.Equal(t, exampleAddress2, model.GetAddress2())
+
+	model.SetAddress3(exampleAddress3)
+	assert.True(t, model.HasAddress3())
+	assert.Equal(t, exampleAddress3, model.GetAddress3())
+
+	model.SetArea(exampleArea)
+	assert.True(t, model.HasArea())
+	assert.Equal(t, exampleArea, model.GetArea())
+
+	model.SetCompany(exampleCompany)
+	assert.True(t, model.HasCompany())
+	assert.Equal(t, exampleCompany, model.GetCompany())
+
+	model.SetCountry(exampleCountry)
+	assert.True(t, model.HasCountry())
+	assert.Equal(t, exampleCountry, model.GetCountry())
+
+	model.SetEmail(exampleEmail)
+	assert.True(t, model.HasEmail())
+	assert.Equal(t, exampleEmail, model.GetEmail())
+
+	model.SetFirstname(exampleFirstname)
+	assert.True(t, model.HasFirstname())
+	assert.Equal(t, exampleFirstname, model.GetFirstname())
+
+	model.SetLastname(exampleLastname)
+	assert.True(t, model.HasLastname())
+	assert.Equal(t, exampleLastname, model.GetLastname())
+
+	model.SetMobileNo(exampleMobile)
+	assert.True(t, model.HasMobileNo())
+	assert.Equal(t, exampleMobile, model.GetMobileNo())
+
+	model.SetPostcode(examplePostcode)
+	assert.True(t, model.HasPostcode())
+	assert.Equal(t, examplePostcode, model.GetPostcode())
+
+	model.SetTelephoneNo(exampleTelephone)
+	assert.True(t, model.HasTelephoneNo())
+	assert.Equal(t, exampleTelephone, model.GetTelephoneNo())
+
+	model.SetTitle(exampleTitle)
+	assert.True(t, model.HasTitle())
+	assert.Equal(t, exampleTitle, model.GetTitle())
+}
+
+func TestContactDetailsJSONRoundTrip(t *testing.T) {
+	model := buildExampleContactDetails()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ContactDetails
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleAddress1, unmarshalled.GetAddress1())
+	assert.Equal(t, exampleCountry, unmarshalled.GetCountry())
+	assert.Equal(t, exampleEmail, unmarshalled.GetEmail())
+}
+
+func TestContactDetailsToMap(t *testing.T) {
+	model := buildExampleContactDetails()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "address1") {
+		assert.Equal(t, &exampleAddress1, m["address1"])
+	}
+	if assert.Contains(t, m, "country") {
+		assert.Equal(t, &exampleCountry, m["country"])
+	}
+}
+
+func TestNullableContactDetailsGetSet(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NullableContactDetails{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableContactDetailsUnset(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NewNullableContactDetails(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableContactDetailsJSONRoundTrip(t *testing.T) {
+	base := buildExampleContactDetails()
+	n := openapiclient.NewNullableContactDetails(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableContactDetails
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleEmail, newN.Get().GetEmail())
+	}
+}

--- a/test/model/model_decision_test.go
+++ b/test/model/model_decision_test.go
@@ -1,0 +1,130 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAcsURL = "https://acs.example.com"
+var exampleCreq = "creqdata"
+var exampleMerchantID int32 = 100
+var exampleThreeDSID = "threedid"
+var exampleTransno int32 = 5
+var exampleAuthMerchant int32 = 321
+var exampleAuthResult int32 = 1
+var exampleAuthCode = "A"
+var exampleAuthMsg = "Approved"
+
+func buildExampleRequestChallenged() openapiclient.RequestChallenged {
+	r := openapiclient.NewRequestChallenged()
+	r.SetAcsUrl(exampleAcsURL)
+	r.SetCreq(exampleCreq)
+	r.SetMerchantid(exampleMerchantID)
+	r.SetThreedserverTransId(exampleThreeDSID)
+	r.SetTransno(exampleTransno)
+	return *r
+}
+
+func buildExampleAuthResp() openapiclient.AuthResponse {
+	a := openapiclient.NewAuthResponse(exampleAuthMerchant, exampleAuthResult, exampleAuthCode, exampleAuthMsg)
+	a.SetAuthcode("CODE")
+	return *a
+}
+
+func buildExampleDecision() *openapiclient.Decision {
+	d := openapiclient.NewDecision()
+	d.SetAuthResponse(buildExampleAuthResp())
+	d.SetRequestChallenged(buildExampleRequestChallenged())
+	return d
+}
+
+func TestNewDecision(t *testing.T) {
+	model := openapiclient.NewDecision()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthResponse())
+	assert.False(t, model.HasRequestChallenged())
+}
+
+func TestNewDecisionWithDefaults(t *testing.T) {
+	model := openapiclient.NewDecisionWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthResponse())
+}
+
+func TestDecisionSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDecision()
+	ar := buildExampleAuthResp()
+	model.SetAuthResponse(ar)
+	assert.True(t, model.HasAuthResponse())
+	assert.Equal(t, ar, model.GetAuthResponse())
+	if val, ok := model.GetAuthResponseOk(); assert.True(t, ok) {
+		assert.Equal(t, ar, *val)
+	}
+
+	rc := buildExampleRequestChallenged()
+	model.SetRequestChallenged(rc)
+	assert.True(t, model.HasRequestChallenged())
+	assert.Equal(t, rc, model.GetRequestChallenged())
+	if val, ok := model.GetRequestChallengedOk(); assert.True(t, ok) {
+		assert.Equal(t, rc, *val)
+	}
+}
+
+func TestDecisionJSONRoundTrip(t *testing.T) {
+	model := buildExampleDecision()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Decision
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasAuthResponse())
+	assert.True(t, unmarshalled.HasRequestChallenged())
+}
+
+func TestDecisionToMap(t *testing.T) {
+	model := buildExampleDecision()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "AuthResponse") {
+		assert.NotNil(t, m["AuthResponse"])
+	}
+	if assert.Contains(t, m, "RequestChallenged") {
+		assert.NotNil(t, m["RequestChallenged"])
+	}
+}
+
+func TestNullableDecisionGetSet(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NullableDecision{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDecisionUnset(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NewNullableDecision(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDecisionJSONRoundTrip(t *testing.T) {
+	base := buildExampleDecision()
+	n := openapiclient.NewNullableDecision(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDecision
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.True(t, newN.Get().HasRequestChallenged())
+	}
+}

--- a/test/model/model_direct_post_request_test.go
+++ b/test/model/model_direct_post_request_test.go
@@ -1,0 +1,208 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDPAmount int32 = 9999
+var exampleDPAvsPolicy = "1"
+var exampleDPCard = "4111111111111111"
+var exampleDPCsc = "123"
+var exampleDPCscPolicy = "2"
+var exampleDPCurrency = "GBP"
+var exampleDPDupPolicy = "1"
+var exampleDPExpMonth int32 = 10
+var exampleDPExpYear int32 = 2026
+var exampleDPIdentifier = "id123"
+var exampleDPMac = "MAC"
+var exampleDPMatchAvsa = "0"
+var exampleDPName = "John Doe"
+var exampleDPNonce = "ABCDEF"
+var exampleDPRedirectFail = "https://fail"
+var exampleDPRedirectSuccess = "https://ok"
+var exampleDPTag = []string{"one", "two"}
+var exampleDPTransInfo = "info"
+var exampleDPTransType = "SALE"
+
+func buildExampleContact() openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1("addr")
+	c.SetEmail("c@example.com")
+	return *c
+}
+
+func buildExampleThreeDS() openapiclient.ThreeDSecure {
+	t := openapiclient.NewThreeDSecure()
+	t.SetAcceptHeaders("text/html")
+	return *t
+}
+
+func buildExampleDirectPostRequest() *openapiclient.DirectPostRequest {
+	d := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	d.SetAvsPostcodePolicy(exampleDPAvsPolicy)
+	d.SetBillTo(buildExampleContact())
+	d.SetCsc(exampleDPCsc)
+	d.SetCscPolicy(exampleDPCscPolicy)
+	d.SetCurrency(exampleDPCurrency)
+	d.SetDuplicatePolicy(exampleDPDupPolicy)
+	d.SetMatchAvsa(exampleDPMatchAvsa)
+	d.SetNameOnCard(exampleDPName)
+	d.SetNonce(exampleDPNonce)
+	d.SetRedirectFailure(exampleDPRedirectFail)
+	d.SetRedirectSuccess(exampleDPRedirectSuccess)
+	d.SetShipTo(buildExampleContact())
+	d.SetTag(exampleDPTag)
+	d.SetThreedsecure(buildExampleThreeDS())
+	d.SetTransInfo(exampleDPTransInfo)
+	d.SetTransType(exampleDPTransType)
+	return d
+}
+
+func TestNewDirectPostRequest(t *testing.T) {
+	model := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDPAmount, model.GetAmount())
+	assert.Equal(t, exampleDPCard, model.GetCardnumber())
+	assert.False(t, model.HasCsc())
+}
+
+func TestNewDirectPostRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDirectPostRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+	assert.Equal(t, "", model.GetCardnumber())
+}
+
+func TestDirectPostRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
+	model.SetAvsPostcodePolicy(exampleDPAvsPolicy)
+	assert.True(t, model.HasAvsPostcodePolicy())
+	assert.Equal(t, exampleDPAvsPolicy, model.GetAvsPostcodePolicy())
+
+	ct := buildExampleContact()
+	model.SetBillTo(ct)
+	assert.True(t, model.HasBillTo())
+	assert.Equal(t, ct, model.GetBillTo())
+
+	model.SetCsc(exampleDPCsc)
+	assert.True(t, model.HasCsc())
+	assert.Equal(t, exampleDPCsc, model.GetCsc())
+
+	model.SetCscPolicy(exampleDPCscPolicy)
+	assert.True(t, model.HasCscPolicy())
+	assert.Equal(t, exampleDPCscPolicy, model.GetCscPolicy())
+
+	model.SetCurrency(exampleDPCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleDPCurrency, model.GetCurrency())
+
+	model.SetDuplicatePolicy(exampleDPDupPolicy)
+	assert.True(t, model.HasDuplicatePolicy())
+	assert.Equal(t, exampleDPDupPolicy, model.GetDuplicatePolicy())
+
+	model.SetMatchAvsa(exampleDPMatchAvsa)
+	assert.True(t, model.HasMatchAvsa())
+	assert.Equal(t, exampleDPMatchAvsa, model.GetMatchAvsa())
+
+	model.SetNameOnCard(exampleDPName)
+	assert.True(t, model.HasNameOnCard())
+	assert.Equal(t, exampleDPName, model.GetNameOnCard())
+
+	model.SetNonce(exampleDPNonce)
+	assert.True(t, model.HasNonce())
+	assert.Equal(t, exampleDPNonce, model.GetNonce())
+
+	model.SetRedirectFailure(exampleDPRedirectFail)
+	assert.True(t, model.HasRedirectFailure())
+	assert.Equal(t, exampleDPRedirectFail, model.GetRedirectFailure())
+
+	model.SetRedirectSuccess(exampleDPRedirectSuccess)
+	assert.True(t, model.HasRedirectSuccess())
+	assert.Equal(t, exampleDPRedirectSuccess, model.GetRedirectSuccess())
+
+	ship := buildExampleContact()
+	model.SetShipTo(ship)
+	assert.True(t, model.HasShipTo())
+	assert.Equal(t, ship, model.GetShipTo())
+
+	model.SetTag(exampleDPTag)
+	assert.True(t, model.HasTag())
+	assert.Equal(t, exampleDPTag, model.GetTag())
+
+	td := buildExampleThreeDS()
+	model.SetThreedsecure(td)
+	assert.True(t, model.HasThreedsecure())
+	assert.Equal(t, td, model.GetThreedsecure())
+
+	model.SetTransInfo(exampleDPTransInfo)
+	assert.True(t, model.HasTransInfo())
+	assert.Equal(t, exampleDPTransInfo, model.GetTransInfo())
+
+	model.SetTransType(exampleDPTransType)
+	assert.True(t, model.HasTransType())
+	assert.Equal(t, exampleDPTransType, model.GetTransType())
+}
+
+func TestDirectPostRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDirectPostRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DirectPostRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleDPAmount, unmarshalled.GetAmount())
+	assert.True(t, unmarshalled.HasCsc())
+	assert.True(t, unmarshalled.HasThreedsecure())
+}
+
+func TestDirectPostRequestToMap(t *testing.T) {
+	model := buildExampleDirectPostRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "amount") {
+		assert.Equal(t, exampleDPAmount, m["amount"])
+	}
+	if assert.Contains(t, m, "avs_postcode_policy") {
+		assert.Equal(t, &exampleDPAvsPolicy, m["avs_postcode_policy"])
+	}
+	if assert.Contains(t, m, "tag") {
+		assert.Equal(t, exampleDPTag, m["tag"])
+	}
+}
+
+func TestNullableDirectPostRequestGetSet(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NullableDirectPostRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDirectPostRequestUnset(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NewNullableDirectPostRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDirectPostRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDirectPostRequest()
+	n := openapiclient.NewNullableDirectPostRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDirectPostRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleDPIdentifier, newN.Get().GetIdentifier())
+	}
+}

--- a/test/model/model_direct_token_auth_request_test.go
+++ b/test/model/model_direct_token_auth_request_test.go
@@ -1,0 +1,107 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleNonce = "ABC"
+var exampleRedirectFail = "https://fail"
+var exampleRedirectSuccess = "https://ok"
+var exampleToken = "tok123"
+
+func buildExampleDirectTokenAuthRequest() *openapiclient.DirectTokenAuthRequest {
+	d := openapiclient.NewDirectTokenAuthRequest()
+	d.SetNonce(exampleNonce)
+	d.SetRedirectFailure(exampleRedirectFail)
+	d.SetRedirectSuccess(exampleRedirectSuccess)
+	d.SetToken(exampleToken)
+	return d
+}
+
+func TestNewDirectTokenAuthRequest(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequest()
+	require.NotNil(t, model)
+	assert.False(t, model.HasToken())
+}
+
+func TestNewDirectTokenAuthRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasToken())
+}
+
+func TestDirectTokenAuthRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDirectTokenAuthRequest()
+	model.SetNonce(exampleNonce)
+	assert.True(t, model.HasNonce())
+	assert.Equal(t, exampleNonce, model.GetNonce())
+
+	model.SetRedirectFailure(exampleRedirectFail)
+	assert.True(t, model.HasRedirectFailure())
+	assert.Equal(t, exampleRedirectFail, model.GetRedirectFailure())
+
+	model.SetRedirectSuccess(exampleRedirectSuccess)
+	assert.True(t, model.HasRedirectSuccess())
+	assert.Equal(t, exampleRedirectSuccess, model.GetRedirectSuccess())
+
+	model.SetToken(exampleToken)
+	assert.True(t, model.HasToken())
+	assert.Equal(t, exampleToken, model.GetToken())
+}
+
+func TestDirectTokenAuthRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDirectTokenAuthRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DirectTokenAuthRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasToken())
+	assert.Equal(t, exampleToken, unmarshalled.GetToken())
+}
+
+func TestDirectTokenAuthRequestToMap(t *testing.T) {
+	model := buildExampleDirectTokenAuthRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "token") {
+		assert.Equal(t, &exampleToken, m["token"])
+	}
+}
+
+func TestNullableDirectTokenAuthRequestGetSet(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NullableDirectTokenAuthRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDirectTokenAuthRequestUnset(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NewNullableDirectTokenAuthRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDirectTokenAuthRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDirectTokenAuthRequest()
+	n := openapiclient.NewNullableDirectTokenAuthRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDirectTokenAuthRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleToken, newN.Get().GetToken())
+	}
+}

--- a/test/model/model_domain_key_check_request_test.go
+++ b/test/model/model_domain_key_check_request_test.go
@@ -1,0 +1,88 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDomainKey = "ABCDEF"
+
+func buildExampleDomainKeyCheckRequest() *openapiclient.DomainKeyCheckRequest {
+	return openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+}
+
+func TestNewDomainKeyCheckRequest(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDomainKey, model.GetDomainKey())
+}
+
+func TestNewDomainKeyCheckRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetDomainKey())
+}
+
+func TestDomainKeyCheckRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyCheckRequest(exampleDomainKey)
+	model.SetDomainKey("XYZ")
+	assert.Equal(t, "XYZ", model.GetDomainKey())
+	if val, ok := model.GetDomainKeyOk(); assert.True(t, ok) {
+		assert.Equal(t, "XYZ", *val)
+	}
+}
+
+func TestDomainKeyCheckRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyCheckRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyCheckRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleDomainKey, unmarshalled.GetDomainKey())
+}
+
+func TestDomainKeyCheckRequestToMap(t *testing.T) {
+	model := buildExampleDomainKeyCheckRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain_key") {
+		assert.Equal(t, exampleDomainKey, m["domain_key"])
+	}
+}
+
+func TestNullableDomainKeyCheckRequestGetSet(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NullableDomainKeyCheckRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyCheckRequestUnset(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NewNullableDomainKeyCheckRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyCheckRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyCheckRequest()
+	n := openapiclient.NewNullableDomainKeyCheckRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyCheckRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleDomainKey, newN.Get().GetDomainKey())
+	}
+}

--- a/test/model/model_domain_key_request_test.go
+++ b/test/model/model_domain_key_request_test.go
@@ -1,0 +1,106 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleDomain = []string{"example.com"}
+var exampleLive = true
+var exampleMerchantID int32 = 50
+
+func buildExampleDomainKeyRequest() *openapiclient.DomainKeyRequest {
+	d := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	d.SetLive(exampleLive)
+	return d
+}
+
+func TestNewDomainKeyRequest(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleDomain, model.GetDomain())
+	assert.Equal(t, exampleMerchantID, model.GetMerchantid())
+	assert.False(t, model.HasLive())
+}
+
+func TestNewDomainKeyRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, 0, len(model.GetDomain()))
+	assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestDomainKeyRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	model.SetDomain([]string{"new.com"})
+	assert.Equal(t, []string{"new.com"}, model.GetDomain())
+
+	model.SetLive(exampleLive)
+	assert.True(t, model.HasLive())
+	assert.Equal(t, exampleLive, model.GetLive())
+	if val, ok := model.GetLiveOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleLive, *val)
+	}
+
+	model.SetMerchantid(99)
+	assert.Equal(t, int32(99), model.GetMerchantid())
+}
+
+func TestDomainKeyRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleMerchantID, unmarshalled.GetMerchantid())
+	assert.True(t, unmarshalled.HasLive())
+}
+
+func TestDomainKeyRequestToMap(t *testing.T) {
+	model := buildExampleDomainKeyRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain") {
+		assert.Equal(t, exampleDomain, m["domain"])
+	}
+	if assert.Contains(t, m, "live") {
+		assert.Equal(t, &exampleLive, m["live"])
+	}
+}
+
+func TestNullableDomainKeyRequestGetSet(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NullableDomainKeyRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyRequestUnset(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NewNullableDomainKeyRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyRequest()
+	n := openapiclient.NewNullableDomainKeyRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMerchantID, newN.Get().GetMerchantid())
+	}
+}

--- a/test/model/model_domain_key_response_test.go
+++ b/test/model/model_domain_key_response_test.go
@@ -1,0 +1,116 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleRespDomain = []string{"example.com"}
+var exampleRespDate = time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
+var exampleRespDomainKey = "KEY"
+var exampleRespLive = true
+var exampleRespMerchant int32 = 55
+
+func buildExampleDomainKeyResponse() *openapiclient.DomainKeyResponse {
+	d := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	d.SetDateCreated(exampleRespDate)
+	d.SetDomainKey(exampleRespDomainKey)
+	d.SetLive(exampleRespLive)
+	return d
+}
+
+func TestNewDomainKeyResponse(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleRespDomain, model.GetDomain())
+	assert.Equal(t, exampleRespMerchant, model.GetMerchantid())
+	assert.False(t, model.HasDomainKey())
+}
+
+func TestNewDomainKeyResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, 0, len(model.GetDomain()))
+	assert.Equal(t, int32(0), model.GetMerchantid())
+}
+
+func TestDomainKeyResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
+	model.SetDateCreated(exampleRespDate)
+	assert.True(t, model.HasDateCreated())
+	assert.Equal(t, exampleRespDate, model.GetDateCreated())
+
+	model.SetDomain(exampleRespDomain)
+	assert.Equal(t, exampleRespDomain, model.GetDomain())
+
+	model.SetDomainKey(exampleRespDomainKey)
+	assert.True(t, model.HasDomainKey())
+	assert.Equal(t, exampleRespDomainKey, model.GetDomainKey())
+
+	model.SetLive(exampleRespLive)
+	assert.True(t, model.HasLive())
+	assert.Equal(t, exampleRespLive, model.GetLive())
+
+	model.SetMerchantid(99)
+	assert.Equal(t, int32(99), model.GetMerchantid())
+}
+
+func TestDomainKeyResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleDomainKeyResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.DomainKeyResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasDomainKey())
+	assert.Equal(t, exampleRespDomainKey, unmarshalled.GetDomainKey())
+}
+
+func TestDomainKeyResponseToMap(t *testing.T) {
+	model := buildExampleDomainKeyResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "domain_key") {
+		assert.Equal(t, &exampleRespDomainKey, m["domain_key"])
+	}
+	if assert.Contains(t, m, "live") {
+		assert.Equal(t, &exampleRespLive, m["live"])
+	}
+}
+
+func TestNullableDomainKeyResponseGetSet(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NullableDomainKeyResponse{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableDomainKeyResponseUnset(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NewNullableDomainKeyResponse(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableDomainKeyResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleDomainKeyResponse()
+	n := openapiclient.NewNullableDomainKeyResponse(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableDomainKeyResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRespDomainKey, newN.Get().GetDomainKey())
+	}
+}

--- a/test/model/model_error_test.go
+++ b/test/model/model_error_test.go
@@ -1,0 +1,117 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleErrCode = "E001"
+var exampleErrContext = "CTX"
+var exampleErrId = "ID123"
+var exampleErrMsg = "message"
+var exampleErrDate = time.Date(2024, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+func buildExampleError() *openapiclient.Error {
+	e := openapiclient.NewError()
+	e.SetCode(exampleErrCode)
+	e.SetContext(exampleErrContext)
+	e.SetIdentifier(exampleErrId)
+	e.SetMessage(exampleErrMsg)
+	e.SetResponseDt(exampleErrDate)
+	return e
+}
+
+func TestNewError(t *testing.T) {
+	model := openapiclient.NewError()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+}
+
+func TestNewErrorWithDefaults(t *testing.T) {
+	model := openapiclient.NewErrorWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCode())
+}
+
+func TestErrorSetGetCycle(t *testing.T) {
+	model := openapiclient.NewError()
+	model.SetCode(exampleErrCode)
+	assert.True(t, model.HasCode())
+	assert.Equal(t, exampleErrCode, model.GetCode())
+
+	model.SetContext(exampleErrContext)
+	assert.True(t, model.HasContext())
+	assert.Equal(t, exampleErrContext, model.GetContext())
+
+	model.SetIdentifier(exampleErrId)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleErrId, model.GetIdentifier())
+
+	model.SetMessage(exampleErrMsg)
+	assert.True(t, model.HasMessage())
+	assert.Equal(t, exampleErrMsg, model.GetMessage())
+
+	model.SetResponseDt(exampleErrDate)
+	assert.True(t, model.HasResponseDt())
+	assert.Equal(t, exampleErrDate, model.GetResponseDt())
+}
+
+func TestErrorJSONRoundTrip(t *testing.T) {
+	model := buildExampleError()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Error
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCode())
+	assert.Equal(t, exampleErrCode, unmarshalled.GetCode())
+}
+
+func TestErrorToMap(t *testing.T) {
+	model := buildExampleError()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "code") {
+		assert.Equal(t, &exampleErrCode, m["code"])
+	}
+	if assert.Contains(t, m, "response_dt") {
+		assert.Equal(t, &exampleErrDate, m["response_dt"])
+	}
+}
+
+func TestNullableErrorGetSet(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NullableError{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableErrorUnset(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NewNullableError(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableErrorJSONRoundTrip(t *testing.T) {
+	base := buildExampleError()
+	n := openapiclient.NewNullableError(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableError
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleErrCode, newN.Get().GetCode())
+	}
+}

--- a/test/model/model_event_data_model_test.go
+++ b/test/model/model_event_data_model_test.go
@@ -1,0 +1,116 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleEndDate = "2024-12-31"
+var exampleEventId = "EVT1"
+var exampleOrganiser = "ORG1"
+var exampleStartDate = "2024-01-01"
+var examplePayType = "deposit"
+
+func buildExampleEventDataModel() *openapiclient.EventDataModel {
+	e := openapiclient.NewEventDataModel()
+	e.SetEventEndDate(exampleEndDate)
+	e.SetEventId(exampleEventId)
+	e.SetEventOrganiserId(exampleOrganiser)
+	e.SetEventStartDate(exampleStartDate)
+	e.SetPaymentType(examplePayType)
+	return e
+}
+
+func TestNewEventDataModel(t *testing.T) {
+	model := openapiclient.NewEventDataModel()
+	require.NotNil(t, model)
+	assert.False(t, model.HasEventId())
+}
+
+func TestNewEventDataModelWithDefaults(t *testing.T) {
+	model := openapiclient.NewEventDataModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasEventId())
+}
+
+func TestEventDataModelSetGetCycle(t *testing.T) {
+	model := openapiclient.NewEventDataModel()
+	model.SetEventEndDate(exampleEndDate)
+	assert.True(t, model.HasEventEndDate())
+	assert.Equal(t, exampleEndDate, model.GetEventEndDate())
+
+	model.SetEventId(exampleEventId)
+	assert.True(t, model.HasEventId())
+	assert.Equal(t, exampleEventId, model.GetEventId())
+
+	model.SetEventOrganiserId(exampleOrganiser)
+	assert.True(t, model.HasEventOrganiserId())
+	assert.Equal(t, exampleOrganiser, model.GetEventOrganiserId())
+
+	model.SetEventStartDate(exampleStartDate)
+	assert.True(t, model.HasEventStartDate())
+	assert.Equal(t, exampleStartDate, model.GetEventStartDate())
+
+	model.SetPaymentType(examplePayType)
+	assert.True(t, model.HasPaymentType())
+	assert.Equal(t, examplePayType, model.GetPaymentType())
+}
+
+func TestEventDataModelJSONRoundTrip(t *testing.T) {
+	model := buildExampleEventDataModel()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.EventDataModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleEventId, unmarshalled.GetEventId())
+	assert.True(t, unmarshalled.HasEventEndDate())
+}
+
+func TestEventDataModelToMap(t *testing.T) {
+	model := buildExampleEventDataModel()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "event_id") {
+		assert.Equal(t, &exampleEventId, m["event_id"])
+	}
+	if assert.Contains(t, m, "payment_type") {
+		assert.Equal(t, &examplePayType, m["payment_type"])
+	}
+}
+
+func TestNullableEventDataModelGetSet(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NullableEventDataModel{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableEventDataModelUnset(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NewNullableEventDataModel(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableEventDataModelJSONRoundTrip(t *testing.T) {
+	base := buildExampleEventDataModel()
+	n := openapiclient.NewNullableEventDataModel(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableEventDataModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleEventId, newN.Get().GetEventId())
+	}
+}

--- a/test/model/model_exists_test.go
+++ b/test/model/model_exists_test.go
@@ -1,0 +1,105 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleExistsActive = true
+var exampleExistsValue = true
+var exampleExistsDate = time.Date(2024, time.May, 1, 0, 0, 0, 0, time.UTC)
+
+func buildExampleExists() *openapiclient.Exists {
+	e := openapiclient.NewExists(exampleExistsValue)
+	e.SetActive(exampleExistsActive)
+	e.SetLastModified(exampleExistsDate)
+	return e
+}
+
+func TestNewExists(t *testing.T) {
+	model := openapiclient.NewExists(exampleExistsValue)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleExistsValue, model.GetExists())
+	assert.False(t, model.HasActive())
+}
+
+func TestNewExistsWithDefaults(t *testing.T) {
+	model := openapiclient.NewExistsWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasActive())
+	assert.Equal(t, false, model.GetExists())
+}
+
+func TestExistsSetGetCycle(t *testing.T) {
+	model := openapiclient.NewExists(false)
+	model.SetActive(exampleExistsActive)
+	assert.True(t, model.HasActive())
+	assert.Equal(t, exampleExistsActive, model.GetActive())
+
+	model.SetExists(exampleExistsValue)
+	assert.Equal(t, exampleExistsValue, model.GetExists())
+
+	model.SetLastModified(exampleExistsDate)
+	assert.True(t, model.HasLastModified())
+	assert.Equal(t, exampleExistsDate, model.GetLastModified())
+}
+
+func TestExistsJSONRoundTrip(t *testing.T) {
+	model := buildExampleExists()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Exists
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasActive())
+	assert.Equal(t, exampleExistsDate, unmarshalled.GetLastModified())
+}
+
+func TestExistsToMap(t *testing.T) {
+	model := buildExampleExists()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "active") {
+		assert.Equal(t, &exampleExistsActive, m["active"])
+	}
+	if assert.Contains(t, m, "exists") {
+		assert.Equal(t, exampleExistsValue, m["exists"])
+	}
+}
+
+func TestNullableExistsGetSet(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NullableExists{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullableExistsUnset(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NewNullableExists(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableExistsJSONRoundTrip(t *testing.T) {
+	base := buildExampleExists()
+	n := openapiclient.NewNullableExists(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableExists
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleExistsValue, newN.Get().GetExists())
+	}
+}

--- a/test/model/model_external_mpi_test.go
+++ b/test/model/model_external_mpi_test.go
@@ -1,0 +1,139 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleMPIAuthenResult = "Y"
+var exampleMPICavv = "abc123"
+var exampleMPIEci int32 = 5
+var exampleMPIEnrolled = "Y"
+var exampleMPIXid = "xyz987"
+
+func buildExampleExternalMPI() openapiclient.ExternalMPI {
+	m := openapiclient.NewExternalMPI()
+	m.SetAuthenResult(exampleMPIAuthenResult)
+	m.SetCavv(exampleMPICavv)
+	m.SetEci(exampleMPIEci)
+	m.SetEnrolled(exampleMPIEnrolled)
+	m.SetXid(exampleMPIXid)
+	return *m
+}
+
+func TestNewExternalMPI(t *testing.T) {
+	model := openapiclient.NewExternalMPI()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthenResult())
+	assert.False(t, model.HasCavv())
+	assert.False(t, model.HasEci())
+	assert.False(t, model.HasEnrolled())
+	assert.False(t, model.HasXid())
+}
+
+func TestNewExternalMPIWithDefaults(t *testing.T) {
+	model := openapiclient.NewExternalMPIWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthenResult())
+	assert.False(t, model.HasCavv())
+	assert.False(t, model.HasEci())
+	assert.False(t, model.HasEnrolled())
+	assert.False(t, model.HasXid())
+}
+
+func TestExternalMPISetGetCycle(t *testing.T) {
+	model := openapiclient.NewExternalMPI()
+	model.SetAuthenResult("N")
+	assert.Equal(t, "N", model.GetAuthenResult())
+	if val, ok := model.GetAuthenResultOk(); assert.True(t, ok) {
+		assert.Equal(t, "N", *val)
+	}
+
+	model.SetCavv(exampleMPICavv)
+	assert.True(t, model.HasCavv())
+	assert.Equal(t, exampleMPICavv, model.GetCavv())
+
+	model.SetEci(exampleMPIEci)
+	assert.True(t, model.HasEci())
+	assert.Equal(t, exampleMPIEci, model.GetEci())
+
+	model.SetEnrolled(exampleMPIEnrolled)
+	assert.True(t, model.HasEnrolled())
+	assert.Equal(t, exampleMPIEnrolled, model.GetEnrolled())
+
+	model.SetXid(exampleMPIXid)
+	assert.True(t, model.HasXid())
+	assert.Equal(t, exampleMPIXid, model.GetXid())
+}
+
+func TestExternalMPIJSONRoundTrip(t *testing.T) {
+	model := buildExampleExternalMPI()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ExternalMPI
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasAuthenResult())
+	assert.Equal(t, exampleMPICavv, unmarshalled.GetCavv())
+	assert.True(t, unmarshalled.HasEci())
+	assert.Equal(t, exampleMPIEci, unmarshalled.GetEci())
+	assert.True(t, unmarshalled.HasEnrolled())
+	assert.Equal(t, exampleMPIXid, unmarshalled.GetXid())
+}
+
+func TestExternalMPIToMap(t *testing.T) {
+	model := buildExampleExternalMPI()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "authen_result") {
+		assert.Equal(t, &exampleMPIAuthenResult, m["authen_result"])
+	}
+	if assert.Contains(t, m, "cavv") {
+		assert.Equal(t, &exampleMPICavv, m["cavv"])
+	}
+	if assert.Contains(t, m, "eci") {
+		assert.Equal(t, &exampleMPIEci, m["eci"])
+	}
+	if assert.Contains(t, m, "enrolled") {
+		assert.Equal(t, &exampleMPIEnrolled, m["enrolled"])
+	}
+	if assert.Contains(t, m, "xid") {
+		assert.Equal(t, &exampleMPIXid, m["xid"])
+	}
+}
+
+func TestNullableExternalMPIGetSet(t *testing.T) {
+	base := buildExampleExternalMPI()
+	n := openapiclient.NullableExternalMPI{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableExternalMPIUnset(t *testing.T) {
+	base := buildExampleExternalMPI()
+	n := openapiclient.NewNullableExternalMPI(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableExternalMPIJSONRoundTrip(t *testing.T) {
+	base := buildExampleExternalMPI()
+	n := openapiclient.NewNullableExternalMPI(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableExternalMPI
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMPIEci, newN.Get().GetEci())
+	}
+}

--- a/test/model/model_list_merchants_response_test.go
+++ b/test/model/model_list_merchants_response_test.go
@@ -1,0 +1,123 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleListClientName = "ExampleClient"
+var exampleListClientID = "cli123"
+
+func buildExampleMerchant() openapiclient.Merchant {
+	m := openapiclient.NewMerchant()
+	m.SetName("Shop")
+	m.SetMerchantid(99)
+	return *m
+}
+
+func buildExampleListResponse() openapiclient.ListMerchantsResponse {
+	l := openapiclient.NewListMerchantsResponse()
+	l.SetClientName(exampleListClientName)
+	l.SetClientid(exampleListClientID)
+	l.SetMerchants([]openapiclient.Merchant{buildExampleMerchant()})
+	return *l
+}
+
+func TestNewListMerchantsResponse(t *testing.T) {
+	model := openapiclient.NewListMerchantsResponse()
+	require.NotNil(t, model)
+	assert.False(t, model.HasClientName())
+	assert.False(t, model.HasClientid())
+	assert.False(t, model.HasMerchants())
+}
+
+func TestNewListMerchantsResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewListMerchantsResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasClientName())
+	assert.False(t, model.HasClientid())
+	assert.False(t, model.HasMerchants())
+}
+
+func TestListMerchantsResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewListMerchantsResponse()
+	model.SetClientName(exampleListClientName)
+	assert.True(t, model.HasClientName())
+	assert.Equal(t, exampleListClientName, model.GetClientName())
+	if val, ok := model.GetClientNameOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleListClientName, *val)
+	}
+
+	model.SetClientid(exampleListClientID)
+	assert.True(t, model.HasClientid())
+	assert.Equal(t, exampleListClientID, model.GetClientid())
+
+	mer := buildExampleMerchant()
+	model.SetMerchants([]openapiclient.Merchant{mer})
+	assert.True(t, model.HasMerchants())
+	assert.Equal(t, 1, len(model.GetMerchants()))
+}
+
+func TestListMerchantsResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleListResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ListMerchantsResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasClientName())
+	assert.Equal(t, exampleListClientID, unmarshalled.GetClientid())
+	assert.True(t, unmarshalled.HasMerchants())
+	assert.Equal(t, 1, len(unmarshalled.GetMerchants()))
+}
+
+func TestListMerchantsResponseToMap(t *testing.T) {
+	model := buildExampleListResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "client_name") {
+		assert.Equal(t, &exampleListClientName, m["client_name"])
+	}
+	if assert.Contains(t, m, "clientid") {
+		assert.Equal(t, &exampleListClientID, m["clientid"])
+	}
+	if assert.Contains(t, m, "merchants") {
+		assert.Equal(t, model.Merchants, m["merchants"])
+	}
+}
+
+func TestNullableListMerchantsResponseGetSet(t *testing.T) {
+	base := buildExampleListResponse()
+	n := openapiclient.NullableListMerchantsResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableListMerchantsResponseUnset(t *testing.T) {
+	base := buildExampleListResponse()
+	n := openapiclient.NewNullableListMerchantsResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableListMerchantsResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleListResponse()
+	n := openapiclient.NewNullableListMerchantsResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableListMerchantsResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.True(t, newN.Get().HasMerchants())
+	}
+}

--- a/test/model/model_mcc6012_test.go
+++ b/test/model/model_mcc6012_test.go
@@ -1,0 +1,125 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAcc = "12345678"
+var exampleDob = "1980-01-01"
+var exampleLast = "Smith"
+var examplePost = "AB12"
+
+func buildExampleMCC6012() openapiclient.MCC6012 {
+	m := openapiclient.NewMCC6012()
+	m.SetRecipientAccount(exampleAcc)
+	m.SetRecipientDob(exampleDob)
+	m.SetRecipientLastname(exampleLast)
+	m.SetRecipientPostcode(examplePost)
+	return *m
+}
+
+func TestNewMCC6012(t *testing.T) {
+	model := openapiclient.NewMCC6012()
+	require.NotNil(t, model)
+	assert.False(t, model.HasRecipientAccount())
+	assert.False(t, model.HasRecipientDob())
+	assert.False(t, model.HasRecipientLastname())
+	assert.False(t, model.HasRecipientPostcode())
+}
+
+func TestNewMCC6012WithDefaults(t *testing.T) {
+	model := openapiclient.NewMCC6012WithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasRecipientAccount())
+	assert.False(t, model.HasRecipientDob())
+	assert.False(t, model.HasRecipientLastname())
+	assert.False(t, model.HasRecipientPostcode())
+}
+
+func TestMCC6012SetGetCycle(t *testing.T) {
+	model := openapiclient.NewMCC6012()
+	model.SetRecipientAccount(exampleAcc)
+	assert.True(t, model.HasRecipientAccount())
+	assert.Equal(t, exampleAcc, model.GetRecipientAccount())
+	if val, ok := model.GetRecipientAccountOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleAcc, *val)
+	}
+
+	model.SetRecipientDob(exampleDob)
+	assert.True(t, model.HasRecipientDob())
+	assert.Equal(t, exampleDob, model.GetRecipientDob())
+
+	model.SetRecipientLastname(exampleLast)
+	assert.True(t, model.HasRecipientLastname())
+	assert.Equal(t, exampleLast, model.GetRecipientLastname())
+
+	model.SetRecipientPostcode(examplePost)
+	assert.True(t, model.HasRecipientPostcode())
+	assert.Equal(t, examplePost, model.GetRecipientPostcode())
+}
+
+func TestMCC6012JSONRoundTrip(t *testing.T) {
+	model := buildExampleMCC6012()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.MCC6012
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasRecipientAccount())
+	assert.Equal(t, examplePost, unmarshalled.GetRecipientPostcode())
+}
+
+func TestMCC6012ToMap(t *testing.T) {
+	model := buildExampleMCC6012()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "recipient_account") {
+		assert.Equal(t, &exampleAcc, m["recipient_account"])
+	}
+	if assert.Contains(t, m, "recipient_dob") {
+		assert.Equal(t, &exampleDob, m["recipient_dob"])
+	}
+	if assert.Contains(t, m, "recipient_lastname") {
+		assert.Equal(t, &exampleLast, m["recipient_lastname"])
+	}
+	if assert.Contains(t, m, "recipient_postcode") {
+		assert.Equal(t, &examplePost, m["recipient_postcode"])
+	}
+}
+
+func TestNullableMCC6012GetSet(t *testing.T) {
+	base := buildExampleMCC6012()
+	n := openapiclient.NullableMCC6012{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableMCC6012Unset(t *testing.T) {
+	base := buildExampleMCC6012()
+	n := openapiclient.NewNullableMCC6012(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableMCC6012JSONRoundTrip(t *testing.T) {
+	base := buildExampleMCC6012()
+	n := openapiclient.NewNullableMCC6012(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableMCC6012
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleAcc, newN.Get().GetRecipientAccount())
+	}
+}

--- a/test/model/model_merchant_batch_report_request_test.go
+++ b/test/model/model_merchant_batch_report_request_test.go
@@ -1,0 +1,147 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleMBRRFrom = "2025-01-01"
+var exampleMBRRUntil = "2025-01-31"
+var exampleMBRRMax int32 = 50
+var exampleMBRRMerchants = []int32{1, 2}
+var exampleMBRRToken = "next"
+var exampleMBRROrder = "merchant_id"
+
+func buildExampleMerchantBatchReportRequest() openapiclient.MerchantBatchReportRequest {
+	m := openapiclient.NewMerchantBatchReportRequest()
+	m.SetDateFrom(exampleMBRRFrom)
+	m.SetDateUntil(exampleMBRRUntil)
+	m.SetMaxResults(exampleMBRRMax)
+	m.SetMerchantId(exampleMBRRMerchants)
+	m.SetNextToken(exampleMBRRToken)
+	m.SetOrderBy(exampleMBRROrder)
+	return *m
+}
+
+func TestNewMerchantBatchReportRequest(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportRequest()
+	require.NotNil(t, model)
+	assert.False(t, model.HasDateFrom())
+	assert.False(t, model.HasDateUntil())
+	assert.False(t, model.HasMaxResults())
+	assert.False(t, model.HasMerchantId())
+	assert.False(t, model.HasNextToken())
+	assert.False(t, model.HasOrderBy())
+}
+
+func TestNewMerchantBatchReportRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasDateFrom())
+	assert.False(t, model.HasDateUntil())
+	assert.False(t, model.HasMaxResults())
+	assert.False(t, model.HasMerchantId())
+	assert.False(t, model.HasNextToken())
+	assert.False(t, model.HasOrderBy())
+}
+
+func TestMerchantBatchReportRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportRequest()
+	model.SetDateFrom(exampleMBRRFrom)
+	assert.True(t, model.HasDateFrom())
+	assert.Equal(t, exampleMBRRFrom, model.GetDateFrom())
+	if val, ok := model.GetDateFromOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleMBRRFrom, *val)
+	}
+
+	model.SetDateUntil(exampleMBRRUntil)
+	assert.True(t, model.HasDateUntil())
+	assert.Equal(t, exampleMBRRUntil, model.GetDateUntil())
+
+	model.SetMaxResults(exampleMBRRMax)
+	assert.True(t, model.HasMaxResults())
+	assert.Equal(t, exampleMBRRMax, model.GetMaxResults())
+
+	model.SetMerchantId(exampleMBRRMerchants)
+	assert.True(t, model.HasMerchantId())
+	assert.Equal(t, exampleMBRRMerchants, model.GetMerchantId())
+
+	model.SetNextToken(exampleMBRRToken)
+	assert.True(t, model.HasNextToken())
+	assert.Equal(t, exampleMBRRToken, model.GetNextToken())
+
+	model.SetOrderBy(exampleMBRROrder)
+	assert.True(t, model.HasOrderBy())
+	assert.Equal(t, exampleMBRROrder, model.GetOrderBy())
+}
+
+func TestMerchantBatchReportRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleMerchantBatchReportRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.MerchantBatchReportRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasDateFrom())
+	assert.Equal(t, exampleMBRRMax, unmarshalled.GetMaxResults())
+}
+
+func TestMerchantBatchReportRequestToMap(t *testing.T) {
+	model := buildExampleMerchantBatchReportRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "date_from") {
+		assert.Equal(t, &exampleMBRRFrom, m["date_from"])
+	}
+	if assert.Contains(t, m, "date_until") {
+		assert.Equal(t, &exampleMBRRUntil, m["date_until"])
+	}
+	if assert.Contains(t, m, "maxResults") {
+		assert.Equal(t, &exampleMBRRMax, m["maxResults"])
+	}
+	if assert.Contains(t, m, "merchant_id") {
+		assert.Equal(t, exampleMBRRMerchants, m["merchant_id"])
+	}
+	if assert.Contains(t, m, "nextToken") {
+		assert.Equal(t, &exampleMBRRToken, m["nextToken"])
+	}
+	if assert.Contains(t, m, "orderBy") {
+		assert.Equal(t, &exampleMBRROrder, m["orderBy"])
+	}
+}
+
+func TestNullableMerchantBatchReportRequestGetSet(t *testing.T) {
+	base := buildExampleMerchantBatchReportRequest()
+	n := openapiclient.NullableMerchantBatchReportRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableMerchantBatchReportRequestUnset(t *testing.T) {
+	base := buildExampleMerchantBatchReportRequest()
+	n := openapiclient.NewNullableMerchantBatchReportRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableMerchantBatchReportRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleMerchantBatchReportRequest()
+	n := openapiclient.NewNullableMerchantBatchReportRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableMerchantBatchReportRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMBRRUntil, newN.Get().GetDateUntil())
+	}
+}

--- a/test/model/model_merchant_batch_report_response_test.go
+++ b/test/model/model_merchant_batch_report_response_test.go
@@ -1,0 +1,138 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleMBRBatchNo = "BN1"
+var exampleMBRStatus = "Open"
+var exampleMBRCode = "O"
+var exampleMBRCurrency = "GBP"
+var exampleMBRMerchantID int32 = 9
+var exampleMBRCount int32 = 1
+var exampleMBRMax int32 = 10
+var exampleMBRToken = "tok"
+var exampleMBRTime = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+func buildExampleNetSummary() openapiclient.NetSummaryResponse {
+	n := openapiclient.NewNetSummaryResponse()
+	val := int32(100)
+	n.SetNetAmount(val)
+	return *n
+}
+
+func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+	m := openapiclient.NewMerchantBatchResponse()
+	m.SetBatchClosed(exampleMBRTime)
+	m.SetBatchNo(exampleMBRBatchNo)
+	m.SetBatchStatus(exampleMBRStatus)
+	m.SetBatchStatusCode(exampleMBRCode)
+	m.SetCurrency(exampleMBRCurrency)
+	m.SetMerchantid(exampleMBRMerchantID)
+	summary := buildExampleNetSummary()
+	m.SetNetSummary(summary)
+	return *m
+}
+
+func buildExampleMerchantBatchReportResponse() openapiclient.MerchantBatchReportResponse {
+	m := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	m.SetCount(exampleMBRCount)
+	m.SetMaxResults(exampleMBRMax)
+	m.SetNextToken(exampleMBRToken)
+	return *m
+}
+
+func TestNewMerchantBatchReportResponse(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	require.NotNil(t, model)
+	assert.Equal(t, 1, len(model.GetBatches()))
+	assert.False(t, model.HasCount())
+	assert.False(t, model.HasMaxResults())
+	assert.False(t, model.HasNextToken())
+}
+
+func TestNewMerchantBatchReportResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, 0, len(model.GetBatches()))
+}
+
+func TestMerchantBatchReportResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	model.SetCount(exampleMBRCount)
+	assert.True(t, model.HasCount())
+	assert.Equal(t, exampleMBRCount, model.GetCount())
+	model.SetMaxResults(exampleMBRMax)
+	assert.True(t, model.HasMaxResults())
+	assert.Equal(t, exampleMBRMax, model.GetMaxResults())
+	model.SetNextToken(exampleMBRToken)
+	assert.True(t, model.HasNextToken())
+	assert.Equal(t, exampleMBRToken, model.GetNextToken())
+}
+
+func TestMerchantBatchReportResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleMerchantBatchReportResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.MerchantBatchReportResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleMBRMax, unmarshalled.GetMaxResults())
+	assert.True(t, unmarshalled.HasNextToken())
+}
+
+func TestMerchantBatchReportResponseToMap(t *testing.T) {
+	model := buildExampleMerchantBatchReportResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "batches") {
+		assert.Equal(t, model.Batches, m["batches"])
+	}
+	if assert.Contains(t, m, "count") {
+		assert.Equal(t, &exampleMBRCount, m["count"])
+	}
+	if assert.Contains(t, m, "maxResults") {
+		assert.Equal(t, &exampleMBRMax, m["maxResults"])
+	}
+	if assert.Contains(t, m, "nextToken") {
+		assert.Equal(t, &exampleMBRToken, m["nextToken"])
+	}
+}
+
+func TestNullableMerchantBatchReportResponseGetSet(t *testing.T) {
+	base := buildExampleMerchantBatchReportResponse()
+	n := openapiclient.NullableMerchantBatchReportResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableMerchantBatchReportResponseUnset(t *testing.T) {
+	base := buildExampleMerchantBatchReportResponse()
+	n := openapiclient.NewNullableMerchantBatchReportResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableMerchantBatchReportResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleMerchantBatchReportResponse()
+	n := openapiclient.NewNullableMerchantBatchReportResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableMerchantBatchReportResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMBRToken, newN.Get().GetNextToken())
+	}
+}

--- a/test/model/model_merchant_batch_response_test.go
+++ b/test/model/model_merchant_batch_response_test.go
@@ -1,0 +1,164 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleMBRRespClosed = time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)
+var exampleMBRRespNo = "001"
+var exampleMBRRespStatus = "Settled"
+var exampleMBRRespCode = "S"
+var exampleMBRRespCurrency = "GBP"
+var exampleMBRRespMID int32 = 44
+
+func buildExampleNetSummaryResponse() openapiclient.NetSummaryResponse {
+	n := openapiclient.NewNetSummaryResponse()
+	val := int32(55)
+	n.SetNetAmount(val)
+	return *n
+}
+
+func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+	m := openapiclient.NewMerchantBatchResponse()
+	m.SetBatchClosed(exampleMBRRespClosed)
+	m.SetBatchNo(exampleMBRRespNo)
+	m.SetBatchStatus(exampleMBRRespStatus)
+	m.SetBatchStatusCode(exampleMBRRespCode)
+	m.SetCurrency(exampleMBRRespCurrency)
+	m.SetMerchantid(exampleMBRRespMID)
+	summary := buildExampleNetSummaryResponse()
+	m.SetNetSummary(summary)
+	return *m
+}
+
+func TestNewMerchantBatchResponse(t *testing.T) {
+	model := openapiclient.NewMerchantBatchResponse()
+	require.NotNil(t, model)
+	assert.False(t, model.HasBatchClosed())
+	assert.False(t, model.HasBatchNo())
+	assert.False(t, model.HasBatchStatus())
+	assert.False(t, model.HasBatchStatusCode())
+	assert.False(t, model.HasCurrency())
+	assert.False(t, model.HasMerchantid())
+	assert.False(t, model.HasNetSummary())
+}
+
+func TestNewMerchantBatchResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewMerchantBatchResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasBatchClosed())
+	assert.False(t, model.HasBatchNo())
+	assert.False(t, model.HasBatchStatus())
+	assert.False(t, model.HasBatchStatusCode())
+	assert.False(t, model.HasCurrency())
+	assert.False(t, model.HasMerchantid())
+	assert.False(t, model.HasNetSummary())
+}
+
+func TestMerchantBatchResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewMerchantBatchResponse()
+	model.SetBatchClosed(exampleMBRRespClosed)
+	assert.True(t, model.HasBatchClosed())
+	assert.Equal(t, exampleMBRRespClosed, model.GetBatchClosed())
+
+	model.SetBatchNo(exampleMBRRespNo)
+	assert.True(t, model.HasBatchNo())
+	assert.Equal(t, exampleMBRRespNo, model.GetBatchNo())
+
+	model.SetBatchStatus(exampleMBRRespStatus)
+	assert.True(t, model.HasBatchStatus())
+	assert.Equal(t, exampleMBRRespStatus, model.GetBatchStatus())
+
+	model.SetBatchStatusCode(exampleMBRRespCode)
+	assert.True(t, model.HasBatchStatusCode())
+	assert.Equal(t, exampleMBRRespCode, model.GetBatchStatusCode())
+
+	model.SetCurrency(exampleMBRRespCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleMBRRespCurrency, model.GetCurrency())
+
+	model.SetMerchantid(exampleMBRRespMID)
+	assert.True(t, model.HasMerchantid())
+	assert.Equal(t, exampleMBRRespMID, model.GetMerchantid())
+
+	summary := buildExampleNetSummaryResponse()
+	model.SetNetSummary(summary)
+	assert.True(t, model.HasNetSummary())
+	assert.Equal(t, summary, model.GetNetSummary())
+}
+
+func TestMerchantBatchResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleMerchantBatchResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.MerchantBatchResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMerchantid())
+	assert.Equal(t, exampleMBRRespStatus, unmarshalled.GetBatchStatus())
+}
+
+func TestMerchantBatchResponseToMap(t *testing.T) {
+	model := buildExampleMerchantBatchResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "batch_closed") {
+		assert.Equal(t, &exampleMBRRespClosed, m["batch_closed"])
+	}
+	if assert.Contains(t, m, "batch_no") {
+		assert.Equal(t, &exampleMBRRespNo, m["batch_no"])
+	}
+	if assert.Contains(t, m, "batch_status") {
+		assert.Equal(t, &exampleMBRRespStatus, m["batch_status"])
+	}
+	if assert.Contains(t, m, "batch_status_code") {
+		assert.Equal(t, &exampleMBRRespCode, m["batch_status_code"])
+	}
+	if assert.Contains(t, m, "currency") {
+		assert.Equal(t, &exampleMBRRespCurrency, m["currency"])
+	}
+	if assert.Contains(t, m, "merchantid") {
+		assert.Equal(t, &exampleMBRRespMID, m["merchantid"])
+	}
+	if assert.Contains(t, m, "net_summary") {
+		assert.NotNil(t, m["net_summary"])
+	}
+}
+
+func TestNullableMerchantBatchResponseGetSet(t *testing.T) {
+	base := buildExampleMerchantBatchResponse()
+	n := openapiclient.NullableMerchantBatchResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableMerchantBatchResponseUnset(t *testing.T) {
+	base := buildExampleMerchantBatchResponse()
+	n := openapiclient.NewNullableMerchantBatchResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableMerchantBatchResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleMerchantBatchResponse()
+	n := openapiclient.NewNullableMerchantBatchResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableMerchantBatchResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMBRRespNo, newN.Get().GetBatchNo())
+	}
+}

--- a/test/model/model_merchant_test.go
+++ b/test/model/model_merchant_test.go
@@ -1,0 +1,136 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleMerchantCurrency = "GBP"
+var exampleMerchantID int32 = 99
+var exampleMerchantName = "Test Shop"
+var exampleMerchantStatus = "A"
+var exampleMerchantLabel = "Active"
+
+func buildExampleMerchant() openapiclient.Merchant {
+	m := openapiclient.NewMerchant()
+	m.SetCurrency(exampleMerchantCurrency)
+	m.SetMerchantid(exampleMerchantID)
+	m.SetName(exampleMerchantName)
+	m.SetStatus(exampleMerchantStatus)
+	m.SetStatusLabel(exampleMerchantLabel)
+	return *m
+}
+
+func TestNewMerchant(t *testing.T) {
+	model := openapiclient.NewMerchant()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCurrency())
+	assert.False(t, model.HasMerchantid())
+	assert.False(t, model.HasName())
+	assert.False(t, model.HasStatus())
+	assert.False(t, model.HasStatusLabel())
+}
+
+func TestNewMerchantWithDefaults(t *testing.T) {
+	model := openapiclient.NewMerchantWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCurrency())
+	assert.False(t, model.HasMerchantid())
+	assert.False(t, model.HasName())
+	assert.False(t, model.HasStatus())
+	assert.False(t, model.HasStatusLabel())
+}
+
+func TestMerchantSetGetCycle(t *testing.T) {
+	model := openapiclient.NewMerchant()
+	model.SetCurrency(exampleMerchantCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleMerchantCurrency, model.GetCurrency())
+	if val, ok := model.GetCurrencyOk(); assert.True(t, ok) {
+		assert.Equal(t, exampleMerchantCurrency, *val)
+	}
+
+	model.SetMerchantid(exampleMerchantID)
+	assert.True(t, model.HasMerchantid())
+	assert.Equal(t, exampleMerchantID, model.GetMerchantid())
+
+	model.SetName(exampleMerchantName)
+	assert.True(t, model.HasName())
+	assert.Equal(t, exampleMerchantName, model.GetName())
+
+	model.SetStatus(exampleMerchantStatus)
+	assert.True(t, model.HasStatus())
+	assert.Equal(t, exampleMerchantStatus, model.GetStatus())
+
+	model.SetStatusLabel(exampleMerchantLabel)
+	assert.True(t, model.HasStatusLabel())
+	assert.Equal(t, exampleMerchantLabel, model.GetStatusLabel())
+}
+
+func TestMerchantJSONRoundTrip(t *testing.T) {
+	model := buildExampleMerchant()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Merchant
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMerchantid())
+	assert.Equal(t, exampleMerchantCurrency, unmarshalled.GetCurrency())
+}
+
+func TestMerchantToMap(t *testing.T) {
+	model := buildExampleMerchant()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "currency") {
+		assert.Equal(t, &exampleMerchantCurrency, m["currency"])
+	}
+	if assert.Contains(t, m, "merchantid") {
+		assert.Equal(t, &exampleMerchantID, m["merchantid"])
+	}
+	if assert.Contains(t, m, "name") {
+		assert.Equal(t, &exampleMerchantName, m["name"])
+	}
+	if assert.Contains(t, m, "status") {
+		assert.Equal(t, &exampleMerchantStatus, m["status"])
+	}
+	if assert.Contains(t, m, "status_label") {
+		assert.Equal(t, &exampleMerchantLabel, m["status_label"])
+	}
+}
+
+func TestNullableMerchantGetSet(t *testing.T) {
+	base := buildExampleMerchant()
+	n := openapiclient.NullableMerchant{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableMerchantUnset(t *testing.T) {
+	base := buildExampleMerchant()
+	n := openapiclient.NewNullableMerchant(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableMerchantJSONRoundTrip(t *testing.T) {
+	base := buildExampleMerchant()
+	n := openapiclient.NewNullableMerchant(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableMerchant
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleMerchantID, newN.Get().GetMerchantid())
+	}
+}

--- a/test/model/model_net_summary_response_test.go
+++ b/test/model/model_net_summary_response_test.go
@@ -1,0 +1,166 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleCreditAmount = "10.00"
+var exampleCreditCount int32 = 2
+var exampleCreditValue int32 = 1000
+var exampleDebitAmount = "20.00"
+var exampleDebitCount int32 = 3
+var exampleDebitValue int32 = 2000
+var exampleNetAmount int32 = 1000
+var exampleTotalCount int32 = 5
+
+func buildExampleNetSummary() openapiclient.NetSummaryResponse {
+	n := openapiclient.NewNetSummaryResponse()
+	n.SetCreditItemsAmount(exampleCreditAmount)
+	n.SetCreditItemsCount(exampleCreditCount)
+	n.SetCreditItemsValue(exampleCreditValue)
+	n.SetDebitItemsAmount(exampleDebitAmount)
+	n.SetDebitItemsCount(exampleDebitCount)
+	n.SetDebitItemsValue(exampleDebitValue)
+	n.SetNetAmount(exampleNetAmount)
+	n.SetTotalCount(exampleTotalCount)
+	return *n
+}
+
+func TestNewNetSummaryResponse(t *testing.T) {
+	model := openapiclient.NewNetSummaryResponse()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCreditItemsAmount())
+	assert.False(t, model.HasCreditItemsCount())
+	assert.False(t, model.HasCreditItemsValue())
+	assert.False(t, model.HasDebitItemsAmount())
+	assert.False(t, model.HasDebitItemsCount())
+	assert.False(t, model.HasDebitItemsValue())
+	assert.False(t, model.HasNetAmount())
+	assert.False(t, model.HasTotalCount())
+}
+
+func TestNewNetSummaryResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewNetSummaryResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasCreditItemsAmount())
+	assert.False(t, model.HasCreditItemsCount())
+	assert.False(t, model.HasCreditItemsValue())
+	assert.False(t, model.HasDebitItemsAmount())
+	assert.False(t, model.HasDebitItemsCount())
+	assert.False(t, model.HasDebitItemsValue())
+	assert.False(t, model.HasNetAmount())
+	assert.False(t, model.HasTotalCount())
+}
+
+func TestNetSummaryResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewNetSummaryResponse()
+	model.SetCreditItemsAmount(exampleCreditAmount)
+	assert.True(t, model.HasCreditItemsAmount())
+	assert.Equal(t, exampleCreditAmount, model.GetCreditItemsAmount())
+
+	model.SetCreditItemsCount(exampleCreditCount)
+	assert.True(t, model.HasCreditItemsCount())
+	assert.Equal(t, exampleCreditCount, model.GetCreditItemsCount())
+
+	model.SetCreditItemsValue(exampleCreditValue)
+	assert.True(t, model.HasCreditItemsValue())
+	assert.Equal(t, exampleCreditValue, model.GetCreditItemsValue())
+
+	model.SetDebitItemsAmount(exampleDebitAmount)
+	assert.True(t, model.HasDebitItemsAmount())
+	assert.Equal(t, exampleDebitAmount, model.GetDebitItemsAmount())
+
+	model.SetDebitItemsCount(exampleDebitCount)
+	assert.True(t, model.HasDebitItemsCount())
+	assert.Equal(t, exampleDebitCount, model.GetDebitItemsCount())
+
+	model.SetDebitItemsValue(exampleDebitValue)
+	assert.True(t, model.HasDebitItemsValue())
+	assert.Equal(t, exampleDebitValue, model.GetDebitItemsValue())
+
+	model.SetNetAmount(exampleNetAmount)
+	assert.True(t, model.HasNetAmount())
+	assert.Equal(t, exampleNetAmount, model.GetNetAmount())
+
+	model.SetTotalCount(exampleTotalCount)
+	assert.True(t, model.HasTotalCount())
+	assert.Equal(t, exampleTotalCount, model.GetTotalCount())
+}
+
+func TestNetSummaryResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleNetSummary()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.NetSummaryResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasDebitItemsAmount())
+	assert.Equal(t, exampleNetAmount, unmarshalled.GetNetAmount())
+}
+
+func TestNetSummaryResponseToMap(t *testing.T) {
+	model := buildExampleNetSummary()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "credit_items_amount") {
+		assert.Equal(t, &exampleCreditAmount, m["credit_items_amount"])
+	}
+	if assert.Contains(t, m, "credit_items_count") {
+		assert.Equal(t, &exampleCreditCount, m["credit_items_count"])
+	}
+	if assert.Contains(t, m, "credit_items_value") {
+		assert.Equal(t, &exampleCreditValue, m["credit_items_value"])
+	}
+	if assert.Contains(t, m, "debit_items_amount") {
+		assert.Equal(t, &exampleDebitAmount, m["debit_items_amount"])
+	}
+	if assert.Contains(t, m, "debit_items_count") {
+		assert.Equal(t, &exampleDebitCount, m["debit_items_count"])
+	}
+	if assert.Contains(t, m, "debit_items_value") {
+		assert.Equal(t, &exampleDebitValue, m["debit_items_value"])
+	}
+	if assert.Contains(t, m, "net_amount") {
+		assert.Equal(t, &exampleNetAmount, m["net_amount"])
+	}
+	if assert.Contains(t, m, "total_count") {
+		assert.Equal(t, &exampleTotalCount, m["total_count"])
+	}
+}
+
+func TestNullableNetSummaryResponseGetSet(t *testing.T) {
+	base := buildExampleNetSummary()
+	n := openapiclient.NullableNetSummaryResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableNetSummaryResponseUnset(t *testing.T) {
+	base := buildExampleNetSummary()
+	n := openapiclient.NewNullableNetSummaryResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableNetSummaryResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleNetSummary()
+	n := openapiclient.NewNullableNetSummaryResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableNetSummaryResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleTotalCount, newN.Get().GetTotalCount())
+	}
+}

--- a/test/model/model_pa_res_auth_request_test.go
+++ b/test/model/model_pa_res_auth_request_test.go
@@ -1,0 +1,102 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var examplePaMd = "md123"
+var examplePaPares = "paresval"
+
+func buildExamplePaResAuthRequest() *openapiclient.PaResAuthRequest {
+	p := openapiclient.NewPaResAuthRequest(examplePaMd, examplePaPares)
+	return p
+}
+
+func TestNewPaResAuthRequest(t *testing.T) {
+	model := openapiclient.NewPaResAuthRequest(examplePaMd, examplePaPares)
+	require.NotNil(t, model)
+	assert.Equal(t, examplePaMd, model.GetMd())
+	assert.Equal(t, examplePaPares, model.GetPares())
+}
+
+func TestNewPaResAuthRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaResAuthRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetMd())
+	assert.Equal(t, "", model.GetPares())
+}
+
+func TestPaResAuthRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaResAuthRequest(examplePaMd, examplePaPares)
+	model.SetMd("new")
+	assert.Equal(t, "new", model.GetMd())
+	if val, ok := model.GetMdOk(); assert.True(t, ok) {
+		assert.Equal(t, "new", *val)
+	}
+
+	model.SetPares("p")
+	assert.Equal(t, "p", model.GetPares())
+	if val, ok := model.GetParesOk(); assert.True(t, ok) {
+		assert.Equal(t, "p", *val)
+	}
+}
+
+func TestPaResAuthRequestJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaResAuthRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaResAuthRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, examplePaMd, unmarshalled.GetMd())
+	assert.Equal(t, examplePaPares, unmarshalled.GetPares())
+}
+
+func TestPaResAuthRequestToMap(t *testing.T) {
+	model := buildExamplePaResAuthRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "md") {
+		assert.Equal(t, examplePaMd, m["md"])
+	}
+	if assert.Contains(t, m, "pares") {
+		assert.Equal(t, examplePaPares, m["pares"])
+	}
+}
+
+func TestNullablePaResAuthRequestGetSet(t *testing.T) {
+	base := buildExamplePaResAuthRequest()
+	n := openapiclient.NullablePaResAuthRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
+}
+
+func TestNullablePaResAuthRequestUnset(t *testing.T) {
+	base := buildExamplePaResAuthRequest()
+	n := openapiclient.NewNullablePaResAuthRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaResAuthRequestJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaResAuthRequest()
+	n := openapiclient.NewNullablePaResAuthRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaResAuthRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, examplePaMd, newN.Get().GetMd())
+	}
+}

--- a/test/model/model_paylink_address_test.go
+++ b/test/model/model_paylink_address_test.go
@@ -1,0 +1,158 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleAddr1 = "1 Road"
+var exampleAddr2 = "Suite 2"
+var exampleAddr3 = "Floor 3"
+var exampleArea = "City"
+var exampleCountry = "GB"
+var exampleLabel = "Home"
+var examplePostcode = "AB12"
+
+func buildExamplePaylinkAddress() openapiclient.PaylinkAddress {
+	p := openapiclient.NewPaylinkAddress()
+	p.SetAddress1(exampleAddr1)
+	p.SetAddress2(exampleAddr2)
+	p.SetAddress3(exampleAddr3)
+	p.SetArea(exampleArea)
+	p.SetCountry(exampleCountry)
+	p.SetLabel(exampleLabel)
+	p.SetPostcode(examplePostcode)
+	return *p
+}
+
+func TestNewPaylinkAddress(t *testing.T) {
+	model := openapiclient.NewPaylinkAddress()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.False(t, model.HasAddress2())
+	assert.False(t, model.HasAddress3())
+	assert.False(t, model.HasArea())
+	assert.False(t, model.HasCountry())
+	assert.False(t, model.HasLabel())
+	assert.False(t, model.HasPostcode())
+}
+
+func TestNewPaylinkAddressWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaylinkAddressWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAddress1())
+	assert.False(t, model.HasAddress2())
+	assert.False(t, model.HasAddress3())
+	assert.False(t, model.HasArea())
+	assert.False(t, model.HasCountry())
+	assert.False(t, model.HasLabel())
+	assert.False(t, model.HasPostcode())
+}
+
+func TestPaylinkAddressSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaylinkAddress()
+	model.SetAddress1(exampleAddr1)
+	assert.True(t, model.HasAddress1())
+	assert.Equal(t, exampleAddr1, model.GetAddress1())
+	if val, ok := model.GetAddress1Ok(); assert.True(t, ok) {
+		assert.Equal(t, exampleAddr1, *val)
+	}
+
+	model.SetAddress2(exampleAddr2)
+	assert.True(t, model.HasAddress2())
+	assert.Equal(t, exampleAddr2, model.GetAddress2())
+
+	model.SetAddress3(exampleAddr3)
+	assert.True(t, model.HasAddress3())
+	assert.Equal(t, exampleAddr3, model.GetAddress3())
+
+	model.SetArea(exampleArea)
+	assert.True(t, model.HasArea())
+	assert.Equal(t, exampleArea, model.GetArea())
+
+	model.SetCountry(exampleCountry)
+	assert.True(t, model.HasCountry())
+	assert.Equal(t, exampleCountry, model.GetCountry())
+
+	model.SetLabel(exampleLabel)
+	assert.True(t, model.HasLabel())
+	assert.Equal(t, exampleLabel, model.GetLabel())
+
+	model.SetPostcode(examplePostcode)
+	assert.True(t, model.HasPostcode())
+	assert.Equal(t, examplePostcode, model.GetPostcode())
+}
+
+func TestPaylinkAddressJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaylinkAddress()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaylinkAddress
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCountry())
+	assert.Equal(t, exampleAddr2, unmarshalled.GetAddress2())
+}
+
+func TestPaylinkAddressToMap(t *testing.T) {
+	model := buildExamplePaylinkAddress()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "address1") {
+		assert.Equal(t, &exampleAddr1, m["address1"])
+	}
+	if assert.Contains(t, m, "address2") {
+		assert.Equal(t, &exampleAddr2, m["address2"])
+	}
+	if assert.Contains(t, m, "address3") {
+		assert.Equal(t, &exampleAddr3, m["address3"])
+	}
+	if assert.Contains(t, m, "area") {
+		assert.Equal(t, &exampleArea, m["area"])
+	}
+	if assert.Contains(t, m, "country") {
+		assert.Equal(t, &exampleCountry, m["country"])
+	}
+	if assert.Contains(t, m, "label") {
+		assert.Equal(t, &exampleLabel, m["label"])
+	}
+	if assert.Contains(t, m, "postcode") {
+		assert.Equal(t, &examplePostcode, m["postcode"])
+	}
+}
+
+func TestNullablePaylinkAddressGetSet(t *testing.T) {
+	base := buildExamplePaylinkAddress()
+	n := openapiclient.NullablePaylinkAddress{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkAddressUnset(t *testing.T) {
+	base := buildExamplePaylinkAddress()
+	n := openapiclient.NewNullablePaylinkAddress(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkAddressJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaylinkAddress()
+	n := openapiclient.NewNullablePaylinkAddress(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaylinkAddress
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, examplePostcode, newN.Get().GetPostcode())
+	}
+}

--- a/test/model/model_paylink_adjustment_request_test.go
+++ b/test/model/model_paylink_adjustment_request_test.go
@@ -1,0 +1,112 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleAdjAmount int32 = 123
+var exampleAdjIdentifier = "adj-id"
+var exampleAdjReason = "Adjustment reason"
+
+func buildExamplePaylinkAdjustmentRequest() openapiclient.PaylinkAdjustmentRequest {
+    p := openapiclient.NewPaylinkAdjustmentRequest()
+    p.SetAmount(exampleAdjAmount)
+    p.SetIdentifier(exampleAdjIdentifier)
+    p.SetReason(exampleAdjReason)
+    return *p
+}
+
+func TestNewPaylinkAdjustmentRequest(t *testing.T) {
+    model := openapiclient.NewPaylinkAdjustmentRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasReason())
+}
+
+func TestNewPaylinkAdjustmentRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkAdjustmentRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+    assert.False(t, model.HasIdentifier())
+    assert.False(t, model.HasReason())
+}
+
+func TestPaylinkAdjustmentRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkAdjustmentRequest()
+    model.SetAmount(exampleAdjAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleAdjAmount, model.GetAmount())
+
+    model.SetIdentifier(exampleAdjIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleAdjIdentifier, model.GetIdentifier())
+
+    model.SetReason(exampleAdjReason)
+    assert.True(t, model.HasReason())
+    assert.Equal(t, exampleAdjReason, model.GetReason())
+}
+
+func TestPaylinkAdjustmentRequestJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkAdjustmentRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkAdjustmentRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasIdentifier())
+    assert.Equal(t, exampleAdjIdentifier, unmarshalled.GetIdentifier())
+}
+
+func TestPaylinkAdjustmentRequestToMap(t *testing.T) {
+    model := buildExamplePaylinkAdjustmentRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "amount") {
+        assert.Equal(t, &exampleAdjAmount, m["amount"])
+    }
+    if assert.Contains(t, m, "identifier") {
+        assert.Equal(t, &exampleAdjIdentifier, m["identifier"])
+    }
+    if assert.Contains(t, m, "reason") {
+        assert.Equal(t, &exampleAdjReason, m["reason"])
+    }
+}
+
+func TestNullablePaylinkAdjustmentRequestGetSet(t *testing.T) {
+    base := buildExamplePaylinkAdjustmentRequest()
+    n := openapiclient.NullablePaylinkAdjustmentRequest{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkAdjustmentRequestUnset(t *testing.T) {
+    base := buildExamplePaylinkAdjustmentRequest()
+    n := openapiclient.NewNullablePaylinkAdjustmentRequest(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkAdjustmentRequestJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkAdjustmentRequest()
+    n := openapiclient.NewNullablePaylinkAdjustmentRequest(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkAdjustmentRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleAdjReason, newN.Get().GetReason())
+    }
+}
+

--- a/test/model/model_paylink_attachment_request_test.go
+++ b/test/model/model_paylink_attachment_request_test.go
@@ -1,0 +1,115 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleAttData = "dGVzdA=="
+var exampleAttFilename = "test.pdf"
+var exampleAttMime = "application/pdf"
+var exampleAttName = "Invoice"
+var exampleAttRetention int32 = 10
+
+func buildExamplePaylinkAttachmentRequest() openapiclient.PaylinkAttachmentRequest {
+    a := openapiclient.NewPaylinkAttachmentRequest(exampleAttFilename, exampleAttMime)
+    a.SetData(exampleAttData)
+    a.SetName(exampleAttName)
+    a.SetRetention(exampleAttRetention)
+    return *a
+}
+
+func TestNewPaylinkAttachmentRequest(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentRequest(exampleAttFilename, exampleAttMime)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleAttFilename, model.GetFilename())
+    assert.Equal(t, exampleAttMime, model.GetMimeType())
+    assert.False(t, model.HasData())
+}
+
+func TestNewPaylinkAttachmentRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasData())
+    assert.False(t, model.HasName())
+}
+
+func TestPaylinkAttachmentRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentRequest(exampleAttFilename, exampleAttMime)
+    model.SetData(exampleAttData)
+    assert.True(t, model.HasData())
+    assert.Equal(t, exampleAttData, model.GetData())
+
+    model.SetName(exampleAttName)
+    assert.True(t, model.HasName())
+    assert.Equal(t, exampleAttName, model.GetName())
+
+    model.SetRetention(exampleAttRetention)
+    assert.True(t, model.HasRetention())
+    assert.Equal(t, exampleAttRetention, model.GetRetention())
+}
+
+func TestPaylinkAttachmentRequestJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkAttachmentRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkAttachmentRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasName())
+    assert.Equal(t, exampleAttName, unmarshalled.GetName())
+}
+
+func TestPaylinkAttachmentRequestToMap(t *testing.T) {
+    model := buildExamplePaylinkAttachmentRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "data") {
+        assert.Equal(t, &exampleAttData, m["data"])
+    }
+    assert.Equal(t, exampleAttFilename, m["filename"])
+    assert.Equal(t, exampleAttMime, m["mime_type"])
+    if assert.Contains(t, m, "name") {
+        assert.Equal(t, &exampleAttName, m["name"])
+    }
+    if assert.Contains(t, m, "retention") {
+        assert.Equal(t, &exampleAttRetention, m["retention"])
+    }
+}
+
+func TestNullablePaylinkAttachmentRequestGetSet(t *testing.T) {
+    base := buildExamplePaylinkAttachmentRequest()
+    n := openapiclient.NullablePaylinkAttachmentRequest{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkAttachmentRequestUnset(t *testing.T) {
+    base := buildExamplePaylinkAttachmentRequest()
+    n := openapiclient.NewNullablePaylinkAttachmentRequest(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkAttachmentRequestJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkAttachmentRequest()
+    n := openapiclient.NewNullablePaylinkAttachmentRequest(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkAttachmentRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleAttMime, newN.Get().GetMimeType())
+    }
+}
+

--- a/test/model/model_paylink_attachment_result_test.go
+++ b/test/model/model_paylink_attachment_result_test.go
@@ -1,0 +1,96 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleAttResName = "Invoice"
+var exampleAttResResult = "OK"
+var exampleAttResURL = "https://example.com/upload"
+
+func buildExamplePaylinkAttachmentResult() openapiclient.PaylinkAttachmentResult {
+    r := openapiclient.NewPaylinkAttachmentResult(exampleAttResName, exampleAttResResult)
+    r.SetUrl(exampleAttResURL)
+    return *r
+}
+
+func TestNewPaylinkAttachmentResult(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentResult(exampleAttResName, exampleAttResResult)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleAttResName, model.GetName())
+    assert.Equal(t, exampleAttResResult, model.GetResult())
+    assert.False(t, model.HasUrl())
+}
+
+func TestNewPaylinkAttachmentResultWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentResultWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasUrl())
+}
+
+func TestPaylinkAttachmentResultSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkAttachmentResult(exampleAttResName, exampleAttResResult)
+    model.SetUrl(exampleAttResURL)
+    assert.True(t, model.HasUrl())
+    assert.Equal(t, exampleAttResURL, model.GetUrl())
+}
+
+func TestPaylinkAttachmentResultJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkAttachmentResult()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkAttachmentResult
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleAttResResult, unmarshalled.GetResult())
+    assert.True(t, unmarshalled.HasUrl())
+}
+
+func TestPaylinkAttachmentResultToMap(t *testing.T) {
+    model := buildExamplePaylinkAttachmentResult()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleAttResName, m["name"])
+    assert.Equal(t, exampleAttResResult, m["result"])
+    if assert.Contains(t, m, "url") {
+        assert.Equal(t, &exampleAttResURL, m["url"])
+    }
+}
+
+func TestNullablePaylinkAttachmentResultGetSet(t *testing.T) {
+    base := buildExamplePaylinkAttachmentResult()
+    n := openapiclient.NullablePaylinkAttachmentResult{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkAttachmentResultUnset(t *testing.T) {
+    base := buildExamplePaylinkAttachmentResult()
+    n := openapiclient.NewNullablePaylinkAttachmentResult(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkAttachmentResultJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkAttachmentResult()
+    n := openapiclient.NewNullablePaylinkAttachmentResult(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkAttachmentResult
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleAttResName, newN.Get().GetName())
+    }
+}
+

--- a/test/model/model_paylink_bill_payment_token_request_test.go
+++ b/test/model/model_paylink_bill_payment_token_request_test.go
@@ -1,0 +1,163 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleBillAddressee = "Customer"
+var exampleBillDescriptor = "Invoice"
+var exampleBillDue = "2024-07-01"
+var exampleBillMemo = "memo"
+var exampleBillNextTo = "notify@example.com"
+var exampleBillSmsTo = "+44111111111"
+
+func buildExampleAttachment() openapiclient.PaylinkAttachmentRequest {
+    a := openapiclient.NewPaylinkAttachmentRequest("file.pdf", "application/pdf")
+    a.SetData("ZGF0YQ==")
+    return *a
+}
+
+func buildExampleEmailPath() openapiclient.PaylinkEmailNotificationPath {
+    p := openapiclient.NewPaylinkEmailNotificationPath([]string{exampleBillNextTo})
+    return *p
+}
+
+func buildExampleSmsPath() openapiclient.PaylinkSMSNotificationPath {
+    s := openapiclient.NewPaylinkSMSNotificationPath(exampleBillSmsTo)
+    return *s
+}
+
+func buildExampleRequestModel() openapiclient.PaylinkTokenRequestModel {
+    r := openapiclient.NewPaylinkTokenRequestModel(100, "id1", 1)
+    return *r
+}
+
+func buildExamplePaylinkBillPaymentTokenRequest() openapiclient.PaylinkBillPaymentTokenRequest {
+    b := openapiclient.NewPaylinkBillPaymentTokenRequest(buildExampleRequestModel())
+    b.SetAddressee(exampleBillAddressee)
+    b.SetAttachments([]openapiclient.PaylinkAttachmentRequest{buildExampleAttachment()})
+    b.SetDescriptor(exampleBillDescriptor)
+    b.SetDue(exampleBillDue)
+    email := buildExampleEmailPath()
+    b.SetEmailNotificationPath(email)
+    b.SetMemo(exampleBillMemo)
+    sms := buildExampleSmsPath()
+    b.SetSmsNotificationPath(sms)
+    return *b
+}
+
+func TestNewPaylinkBillPaymentTokenRequest(t *testing.T) {
+    model := openapiclient.NewPaylinkBillPaymentTokenRequest(buildExampleRequestModel())
+    require.NotNil(t, model)
+    assert.Equal(t, buildExampleRequestModel(), model.GetRequest())
+    assert.False(t, model.HasAddressee())
+}
+
+func TestNewPaylinkBillPaymentTokenRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkBillPaymentTokenRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAttachments())
+}
+
+func TestPaylinkBillPaymentTokenRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkBillPaymentTokenRequest(buildExampleRequestModel())
+    model.SetAddressee(exampleBillAddressee)
+    assert.True(t, model.HasAddressee())
+    assert.Equal(t, exampleBillAddressee, model.GetAddressee())
+
+    model.SetAttachments([]openapiclient.PaylinkAttachmentRequest{buildExampleAttachment()})
+    assert.True(t, model.HasAttachments())
+    assert.Len(t, model.GetAttachments(), 1)
+
+    model.SetDescriptor(exampleBillDescriptor)
+    assert.True(t, model.HasDescriptor())
+    assert.Equal(t, exampleBillDescriptor, model.GetDescriptor())
+
+    model.SetDue(exampleBillDue)
+    assert.True(t, model.HasDue())
+    assert.Equal(t, exampleBillDue, model.GetDue())
+
+    email := buildExampleEmailPath()
+    model.SetEmailNotificationPath(email)
+    assert.True(t, model.HasEmailNotificationPath())
+    assert.Equal(t, email, model.GetEmailNotificationPath())
+
+    model.SetMemo(exampleBillMemo)
+    assert.True(t, model.HasMemo())
+    assert.Equal(t, exampleBillMemo, model.GetMemo())
+
+    sms := buildExampleSmsPath()
+    model.SetSmsNotificationPath(sms)
+    assert.True(t, model.HasSmsNotificationPath())
+    assert.Equal(t, sms, model.GetSmsNotificationPath())
+}
+
+func TestPaylinkBillPaymentTokenRequestJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkBillPaymentTokenRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkBillPaymentTokenRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasDescriptor())
+    assert.Equal(t, exampleBillDescriptor, unmarshalled.GetDescriptor())
+}
+
+func TestPaylinkBillPaymentTokenRequestToMap(t *testing.T) {
+    model := buildExamplePaylinkBillPaymentTokenRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "addressee") {
+        assert.Equal(t, &exampleBillAddressee, m["addressee"])
+    }
+    if assert.Contains(t, m, "attachments") {
+        assert.Len(t, m["attachments"], 1)
+    }
+    if assert.Contains(t, m, "descriptor") {
+        assert.Equal(t, &exampleBillDescriptor, m["descriptor"])
+    }
+    if assert.Contains(t, m, "due") {
+        assert.Equal(t, &exampleBillDue, m["due"])
+    }
+    if assert.Contains(t, m, "memo") {
+        assert.Equal(t, &exampleBillMemo, m["memo"])
+    }
+}
+
+func TestNullablePaylinkBillPaymentTokenRequestGetSet(t *testing.T) {
+    base := buildExamplePaylinkBillPaymentTokenRequest()
+    n := openapiclient.NullablePaylinkBillPaymentTokenRequest{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkBillPaymentTokenRequestUnset(t *testing.T) {
+    base := buildExamplePaylinkBillPaymentTokenRequest()
+    n := openapiclient.NewNullablePaylinkBillPaymentTokenRequest(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkBillPaymentTokenRequestJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkBillPaymentTokenRequest()
+    n := openapiclient.NewNullablePaylinkBillPaymentTokenRequest(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkBillPaymentTokenRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.True(t, newN.Get().HasAddressee())
+    }
+}
+

--- a/test/model/model_paylink_card_holder_test.go
+++ b/test/model/model_paylink_card_holder_test.go
@@ -1,0 +1,154 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleHolderAccept = "text/html"
+var exampleHolderCompany = "Company"
+var exampleHolderEmail = "a@example.com"
+var exampleHolderFirst = "John"
+var exampleHolderLast = "Smith"
+var exampleHolderMobile = "+4411111111"
+var exampleHolderRemote = "1.1.1.1"
+var exampleHolderTitle = "Mr"
+var exampleHolderUA = "UA"
+
+func buildExamplePaylinkAddress() openapiclient.PaylinkAddress {
+    a := openapiclient.NewPaylinkAddress()
+    a.SetCountry("GB")
+    return *a
+}
+
+func buildExamplePaylinkCardHolder() openapiclient.PaylinkCardHolder {
+    h := openapiclient.NewPaylinkCardHolder()
+    h.SetAcceptHeaders(exampleHolderAccept)
+    addr := buildExamplePaylinkAddress()
+    h.SetAddress(addr)
+    h.SetCompany(exampleHolderCompany)
+    h.SetEmail(exampleHolderEmail)
+    h.SetFirstname(exampleHolderFirst)
+    h.SetLastname(exampleHolderLast)
+    h.SetMobileNo(exampleHolderMobile)
+    h.SetRemoteAddr(exampleHolderRemote)
+    h.SetTitle(exampleHolderTitle)
+    h.SetUserAgent(exampleHolderUA)
+    return *h
+}
+
+func TestNewPaylinkCardHolder(t *testing.T) {
+    model := openapiclient.NewPaylinkCardHolder()
+    require.NotNil(t, model)
+    assert.False(t, model.HasEmail())
+}
+
+func TestNewPaylinkCardHolderWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkCardHolderWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasFirstname())
+}
+
+func TestPaylinkCardHolderSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkCardHolder()
+    model.SetAcceptHeaders(exampleHolderAccept)
+    assert.True(t, model.HasAcceptHeaders())
+    assert.Equal(t, exampleHolderAccept, model.GetAcceptHeaders())
+
+    addr := buildExamplePaylinkAddress()
+    model.SetAddress(addr)
+    assert.True(t, model.HasAddress())
+    assert.Equal(t, addr, model.GetAddress())
+
+    model.SetCompany(exampleHolderCompany)
+    assert.True(t, model.HasCompany())
+    assert.Equal(t, exampleHolderCompany, model.GetCompany())
+
+    model.SetEmail(exampleHolderEmail)
+    assert.True(t, model.HasEmail())
+    assert.Equal(t, exampleHolderEmail, model.GetEmail())
+
+    model.SetFirstname(exampleHolderFirst)
+    assert.True(t, model.HasFirstname())
+    assert.Equal(t, exampleHolderFirst, model.GetFirstname())
+
+    model.SetLastname(exampleHolderLast)
+    assert.True(t, model.HasLastname())
+    assert.Equal(t, exampleHolderLast, model.GetLastname())
+
+    model.SetMobileNo(exampleHolderMobile)
+    assert.True(t, model.HasMobileNo())
+    assert.Equal(t, exampleHolderMobile, model.GetMobileNo())
+
+    model.SetRemoteAddr(exampleHolderRemote)
+    assert.True(t, model.HasRemoteAddr())
+    assert.Equal(t, exampleHolderRemote, model.GetRemoteAddr())
+
+    model.SetTitle(exampleHolderTitle)
+    assert.True(t, model.HasTitle())
+    assert.Equal(t, exampleHolderTitle, model.GetTitle())
+
+    model.SetUserAgent(exampleHolderUA)
+    assert.True(t, model.HasUserAgent())
+    assert.Equal(t, exampleHolderUA, model.GetUserAgent())
+}
+
+func TestPaylinkCardHolderJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkCardHolder()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkCardHolder
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasRemoteAddr())
+    assert.Equal(t, exampleHolderRemote, unmarshalled.GetRemoteAddr())
+}
+
+func TestPaylinkCardHolderToMap(t *testing.T) {
+    model := buildExamplePaylinkCardHolder()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "accept_headers") {
+        assert.Equal(t, &exampleHolderAccept, m["accept_headers"])
+    }
+    if assert.Contains(t, m, "company") {
+        assert.Equal(t, &exampleHolderCompany, m["company"])
+    }
+}
+
+func TestNullablePaylinkCardHolderGetSet(t *testing.T) {
+    base := buildExamplePaylinkCardHolder()
+    n := openapiclient.NullablePaylinkCardHolder{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkCardHolderUnset(t *testing.T) {
+    base := buildExamplePaylinkCardHolder()
+    n := openapiclient.NewNullablePaylinkCardHolder(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkCardHolderJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkCardHolder()
+    n := openapiclient.NewNullablePaylinkCardHolder(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkCardHolder
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleHolderFirst, newN.Get().GetFirstname())
+    }
+}
+

--- a/test/model/model_paylink_cart_item_model_test.go
+++ b/test/model/model_paylink_cart_item_model_test.go
@@ -1,0 +1,135 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleItemAmount int32 = 99
+var exampleItemBrand = "Brand"
+var exampleItemCategory = "Cat"
+var exampleItemCount int32 = 2
+var exampleItemLabel = "Label"
+var exampleItemMax int32 = 5
+var exampleItemSku = "SKU1"
+var exampleItemVariant = "Var"
+
+func buildExamplePaylinkCartItemModel() openapiclient.PaylinkCartItemModel {
+    i := openapiclient.NewPaylinkCartItemModel()
+    i.SetAmount(exampleItemAmount)
+    i.SetBrand(exampleItemBrand)
+    i.SetCategory(exampleItemCategory)
+    i.SetCount(exampleItemCount)
+    i.SetLabel(exampleItemLabel)
+    i.SetMax(exampleItemMax)
+    i.SetSku(exampleItemSku)
+    i.SetVariant(exampleItemVariant)
+    return *i
+}
+
+func TestNewPaylinkCartItemModel(t *testing.T) {
+    model := openapiclient.NewPaylinkCartItemModel()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+}
+
+func TestNewPaylinkCartItemModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkCartItemModelWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasLabel())
+}
+
+func TestPaylinkCartItemModelSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkCartItemModel()
+    model.SetAmount(exampleItemAmount)
+    assert.True(t, model.HasAmount())
+    assert.Equal(t, exampleItemAmount, model.GetAmount())
+
+    model.SetBrand(exampleItemBrand)
+    assert.True(t, model.HasBrand())
+    assert.Equal(t, exampleItemBrand, model.GetBrand())
+
+    model.SetCategory(exampleItemCategory)
+    assert.True(t, model.HasCategory())
+    assert.Equal(t, exampleItemCategory, model.GetCategory())
+
+    model.SetCount(exampleItemCount)
+    assert.True(t, model.HasCount())
+    assert.Equal(t, exampleItemCount, model.GetCount())
+
+    model.SetLabel(exampleItemLabel)
+    assert.True(t, model.HasLabel())
+    assert.Equal(t, exampleItemLabel, model.GetLabel())
+
+    model.SetMax(exampleItemMax)
+    assert.True(t, model.HasMax())
+    assert.Equal(t, exampleItemMax, model.GetMax())
+
+    model.SetSku(exampleItemSku)
+    assert.True(t, model.HasSku())
+    assert.Equal(t, exampleItemSku, model.GetSku())
+
+    model.SetVariant(exampleItemVariant)
+    assert.True(t, model.HasVariant())
+    assert.Equal(t, exampleItemVariant, model.GetVariant())
+}
+
+func TestPaylinkCartItemModelJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkCartItemModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkCartItemModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasBrand())
+    assert.Equal(t, exampleItemBrand, unmarshalled.GetBrand())
+}
+
+func TestPaylinkCartItemModelToMap(t *testing.T) {
+    model := buildExamplePaylinkCartItemModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "sku") {
+        assert.Equal(t, &exampleItemSku, m["sku"])
+    }
+    if assert.Contains(t, m, "variant") {
+        assert.Equal(t, &exampleItemVariant, m["variant"])
+    }
+}
+
+func TestNullablePaylinkCartItemModelGetSet(t *testing.T) {
+    base := buildExamplePaylinkCartItemModel()
+    n := openapiclient.NullablePaylinkCartItemModel{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkCartItemModelUnset(t *testing.T) {
+    base := buildExamplePaylinkCartItemModel()
+    n := openapiclient.NewNullablePaylinkCartItemModel(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkCartItemModelJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkCartItemModel()
+    n := openapiclient.NewNullablePaylinkCartItemModel(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkCartItemModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleItemAmount, newN.Get().GetAmount())
+    }
+}
+

--- a/test/model/model_paylink_cart_test.go
+++ b/test/model/model_paylink_cart_test.go
@@ -1,0 +1,134 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleCartCoupon = "NEW10"
+var exampleCartMode int32 = 2
+var exampleCartProdDesc = "Product"
+var exampleCartProdInfo = "Info"
+var exampleCartShipping int32 = 50
+var exampleCartTax int32 = 20
+
+func buildExampleCartItem() openapiclient.PaylinkCartItemModel {
+    i := openapiclient.NewPaylinkCartItemModel()
+    i.SetLabel("Item")
+    return *i
+}
+
+func buildExamplePaylinkCart() openapiclient.PaylinkCart {
+    c := openapiclient.NewPaylinkCart()
+    c.SetContents([]openapiclient.PaylinkCartItemModel{buildExampleCartItem()})
+    c.SetCoupon(exampleCartCoupon)
+    c.SetMode(exampleCartMode)
+    c.SetProductDescription(exampleCartProdDesc)
+    c.SetProductInformation(exampleCartProdInfo)
+    c.SetShipping(exampleCartShipping)
+    c.SetTax(exampleCartTax)
+    return *c
+}
+
+func TestNewPaylinkCart(t *testing.T) {
+    model := openapiclient.NewPaylinkCart()
+    require.NotNil(t, model)
+    assert.False(t, model.HasCoupon())
+}
+
+func TestNewPaylinkCartWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkCartWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasContents())
+}
+
+func TestPaylinkCartSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkCart()
+    model.SetContents([]openapiclient.PaylinkCartItemModel{buildExampleCartItem()})
+    assert.True(t, model.HasContents())
+    assert.Len(t, model.GetContents(), 1)
+
+    model.SetCoupon(exampleCartCoupon)
+    assert.True(t, model.HasCoupon())
+    assert.Equal(t, exampleCartCoupon, model.GetCoupon())
+
+    model.SetMode(exampleCartMode)
+    assert.True(t, model.HasMode())
+    assert.Equal(t, exampleCartMode, model.GetMode())
+
+    model.SetProductDescription(exampleCartProdDesc)
+    assert.True(t, model.HasProductDescription())
+    assert.Equal(t, exampleCartProdDesc, model.GetProductDescription())
+
+    model.SetProductInformation(exampleCartProdInfo)
+    assert.True(t, model.HasProductInformation())
+    assert.Equal(t, exampleCartProdInfo, model.GetProductInformation())
+
+    model.SetShipping(exampleCartShipping)
+    assert.True(t, model.HasShipping())
+    assert.Equal(t, exampleCartShipping, model.GetShipping())
+
+    model.SetTax(exampleCartTax)
+    assert.True(t, model.HasTax())
+    assert.Equal(t, exampleCartTax, model.GetTax())
+}
+
+func TestPaylinkCartJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkCart()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkCart
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasMode())
+    assert.Equal(t, exampleCartMode, unmarshalled.GetMode())
+}
+
+func TestPaylinkCartToMap(t *testing.T) {
+    model := buildExamplePaylinkCart()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "coupon") {
+        assert.Equal(t, &exampleCartCoupon, m["coupon"])
+    }
+    if assert.Contains(t, m, "tax") {
+        assert.Equal(t, &exampleCartTax, m["tax"])
+    }
+}
+
+func TestNullablePaylinkCartGetSet(t *testing.T) {
+    base := buildExamplePaylinkCart()
+    n := openapiclient.NullablePaylinkCart{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkCartUnset(t *testing.T) {
+    base := buildExamplePaylinkCart()
+    n := openapiclient.NewNullablePaylinkCart(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkCartJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkCart()
+    n := openapiclient.NewNullablePaylinkCart(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkCart
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleCartShipping, newN.Get().GetShipping())
+    }
+}
+

--- a/test/model/model_paylink_config_test.go
+++ b/test/model/model_paylink_config_test.go
@@ -1,0 +1,239 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleConfigAcs = "iframe"
+var exampleConfigDescriptor = "desc"
+var exampleConfigExpire = "30m"
+var exampleConfigLock = []string{"x"}
+var exampleConfigLogo = "https://img"
+var exampleConfigTerms = "https://terms"
+var exampleConfigOptions = []string{"o1"}
+var exampleConfigPostback = "https://post"
+var exampleConfigPassword = "pass"
+var exampleConfigPolicy = "ALWAYS"
+var exampleConfigUser = "user"
+var exampleConfigDelay int32 = 5
+var exampleConfigFail = "https://fail"
+var exampleConfigSuccess = "https://ok"
+var exampleConfigRenderer = "default"
+var exampleConfigReturn = true
+
+func buildExampleCustomParam() openapiclient.PaylinkCustomParam {
+    c := openapiclient.NewPaylinkCustomParam("p")
+    c.SetLabel("label")
+    return *c
+}
+
+func buildExampleFieldGuard() openapiclient.PaylinkFieldGuardModel {
+    f := openapiclient.NewPaylinkFieldGuardModel()
+    f.SetName("n")
+    return *f
+}
+
+func buildExamplePartPayments() openapiclient.PaylinkPartPayments {
+    p := openapiclient.NewPaylinkPartPayments()
+    p.SetEnabled("true")
+    return *p
+}
+
+func buildExampleUI() openapiclient.PaylinkUI {
+    u := openapiclient.NewPaylinkUI()
+    u.SetOrdering(1)
+    return *u
+}
+
+func buildExamplePaylinkConfig() openapiclient.PaylinkConfig {
+    c := openapiclient.NewPaylinkConfig()
+    c.SetAcsMode(exampleConfigAcs)
+    c.SetCustomParams([]openapiclient.PaylinkCustomParam{buildExampleCustomParam()})
+    c.SetDescriptor(exampleConfigDescriptor)
+    c.SetExpireIn(exampleConfigExpire)
+    c.SetFieldGuard([]openapiclient.PaylinkFieldGuardModel{buildExampleFieldGuard()})
+    c.SetLockParams(exampleConfigLock)
+    c.SetMerchLogo(exampleConfigLogo)
+    c.SetMerchTerms(exampleConfigTerms)
+    c.SetOptions(exampleConfigOptions)
+    c.SetPartPayments(buildExamplePartPayments())
+    m := map[string]string{"k": "v"}
+    c.SetPassThroughData(m)
+    c.SetPassThroughHeaders(m)
+    c.SetPostback(exampleConfigPostback)
+    c.SetPostbackPassword(exampleConfigPassword)
+    c.SetPostbackPolicy(exampleConfigPolicy)
+    c.SetPostbackUsername(exampleConfigUser)
+    c.SetRedirectDelay(exampleConfigDelay)
+    c.SetRedirectFailure(exampleConfigFail)
+    c.SetRedirectSuccess(exampleConfigSuccess)
+    c.SetRenderer(exampleConfigRenderer)
+    c.SetReturnParams(exampleConfigReturn)
+    c.SetUi(buildExampleUI())
+    return *c
+}
+
+func TestNewPaylinkConfig(t *testing.T) {
+    model := openapiclient.NewPaylinkConfig()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAcsMode())
+}
+
+func TestNewPaylinkConfigWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkConfigWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasOptions())
+}
+
+func TestPaylinkConfigSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkConfig()
+    model.SetAcsMode(exampleConfigAcs)
+    assert.True(t, model.HasAcsMode())
+    assert.Equal(t, exampleConfigAcs, model.GetAcsMode())
+
+    model.SetCustomParams([]openapiclient.PaylinkCustomParam{buildExampleCustomParam()})
+    assert.True(t, model.HasCustomParams())
+    assert.Len(t, model.GetCustomParams(), 1)
+
+    model.SetDescriptor(exampleConfigDescriptor)
+    assert.True(t, model.HasDescriptor())
+    assert.Equal(t, exampleConfigDescriptor, model.GetDescriptor())
+
+    model.SetExpireIn(exampleConfigExpire)
+    assert.True(t, model.HasExpireIn())
+    assert.Equal(t, exampleConfigExpire, model.GetExpireIn())
+
+    model.SetFieldGuard([]openapiclient.PaylinkFieldGuardModel{buildExampleFieldGuard()})
+    assert.True(t, model.HasFieldGuard())
+    assert.Len(t, model.GetFieldGuard(), 1)
+
+    model.SetLockParams(exampleConfigLock)
+    assert.True(t, model.HasLockParams())
+    assert.Equal(t, exampleConfigLock, model.GetLockParams())
+
+    model.SetMerchLogo(exampleConfigLogo)
+    assert.True(t, model.HasMerchLogo())
+    assert.Equal(t, exampleConfigLogo, model.GetMerchLogo())
+
+    model.SetMerchTerms(exampleConfigTerms)
+    assert.True(t, model.HasMerchTerms())
+    assert.Equal(t, exampleConfigTerms, model.GetMerchTerms())
+
+    model.SetOptions(exampleConfigOptions)
+    assert.True(t, model.HasOptions())
+    assert.Equal(t, exampleConfigOptions, model.GetOptions())
+
+    part := buildExamplePartPayments()
+    model.SetPartPayments(part)
+    assert.True(t, model.HasPartPayments())
+    assert.Equal(t, part, model.GetPartPayments())
+
+    m := map[string]string{"k": "v"}
+    model.SetPassThroughData(m)
+    assert.True(t, model.HasPassThroughData())
+
+    model.SetPassThroughHeaders(m)
+    assert.True(t, model.HasPassThroughHeaders())
+
+    model.SetPostback(exampleConfigPostback)
+    assert.True(t, model.HasPostback())
+    assert.Equal(t, exampleConfigPostback, model.GetPostback())
+
+    model.SetPostbackPassword(exampleConfigPassword)
+    assert.True(t, model.HasPostbackPassword())
+    assert.Equal(t, exampleConfigPassword, model.GetPostbackPassword())
+
+    model.SetPostbackPolicy(exampleConfigPolicy)
+    assert.True(t, model.HasPostbackPolicy())
+    assert.Equal(t, exampleConfigPolicy, model.GetPostbackPolicy())
+
+    model.SetPostbackUsername(exampleConfigUser)
+    assert.True(t, model.HasPostbackUsername())
+    assert.Equal(t, exampleConfigUser, model.GetPostbackUsername())
+
+    model.SetRedirectDelay(exampleConfigDelay)
+    assert.True(t, model.HasRedirectDelay())
+    assert.Equal(t, exampleConfigDelay, model.GetRedirectDelay())
+
+    model.SetRedirectFailure(exampleConfigFail)
+    assert.True(t, model.HasRedirectFailure())
+    assert.Equal(t, exampleConfigFail, model.GetRedirectFailure())
+
+    model.SetRedirectSuccess(exampleConfigSuccess)
+    assert.True(t, model.HasRedirectSuccess())
+    assert.Equal(t, exampleConfigSuccess, model.GetRedirectSuccess())
+
+    model.SetRenderer(exampleConfigRenderer)
+    assert.True(t, model.HasRenderer())
+    assert.Equal(t, exampleConfigRenderer, model.GetRenderer())
+
+    model.SetReturnParams(exampleConfigReturn)
+    assert.True(t, model.HasReturnParams())
+    assert.Equal(t, exampleConfigReturn, model.GetReturnParams())
+
+    ui := buildExampleUI()
+    model.SetUi(ui)
+    assert.True(t, model.HasUi())
+    assert.Equal(t, ui, model.GetUi())
+}
+
+func TestPaylinkConfigJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkConfig()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkConfig
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAcsMode())
+    assert.Equal(t, exampleConfigAcs, unmarshalled.GetAcsMode())
+}
+
+func TestPaylinkConfigToMap(t *testing.T) {
+    model := buildExamplePaylinkConfig()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "descriptor") {
+        assert.Equal(t, &exampleConfigDescriptor, m["descriptor"])
+    }
+    if assert.Contains(t, m, "renderer") {
+        assert.Equal(t, &exampleConfigRenderer, m["renderer"])
+    }
+}
+
+func TestNullablePaylinkConfigGetSet(t *testing.T) {
+    base := buildExamplePaylinkConfig()
+    n := openapiclient.NullablePaylinkConfig{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkConfigUnset(t *testing.T) {
+    base := buildExamplePaylinkConfig()
+    n := openapiclient.NewNullablePaylinkConfig(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkConfigJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkConfig()
+    n := openapiclient.NewNullablePaylinkConfig(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkConfig
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleConfigFail, newN.Get().GetRedirectFailure())
+    }
+}
+

--- a/test/model/model_paylink_custom_param_test.go
+++ b/test/model/model_paylink_custom_param_test.go
@@ -1,0 +1,147 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleParamEntry = "pre"
+var exampleParamField = "text"
+var exampleParamGroup = "g"
+var exampleParamLabel = "lbl"
+var exampleParamLocked = true
+var exampleParamName = "p"
+var exampleParamOrder int32 = 1
+var exampleParamPattern = "[0-9]"
+var exampleParamPlaceholder = "ph"
+var exampleParamRequired = true
+var exampleParamValue = "val"
+
+func buildExamplePaylinkCustomParam() openapiclient.PaylinkCustomParam {
+    p := openapiclient.NewPaylinkCustomParam(exampleParamName)
+    p.SetEntryMode(exampleParamEntry)
+    p.SetFieldType(exampleParamField)
+    p.SetGroup(exampleParamGroup)
+    p.SetLabel(exampleParamLabel)
+    p.SetLocked(exampleParamLocked)
+    p.SetOrder(exampleParamOrder)
+    p.SetPattern(exampleParamPattern)
+    p.SetPlaceholder(exampleParamPlaceholder)
+    p.SetRequired(exampleParamRequired)
+    p.SetValue(exampleParamValue)
+    return *p
+}
+
+func TestNewPaylinkCustomParam(t *testing.T) {
+    model := openapiclient.NewPaylinkCustomParam(exampleParamName)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleParamName, model.GetName())
+    assert.False(t, model.HasLocked())
+}
+
+func TestNewPaylinkCustomParamWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkCustomParamWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasEntryMode())
+}
+
+func TestPaylinkCustomParamSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkCustomParam(exampleParamName)
+    model.SetEntryMode(exampleParamEntry)
+    assert.True(t, model.HasEntryMode())
+    assert.Equal(t, exampleParamEntry, model.GetEntryMode())
+
+    model.SetFieldType(exampleParamField)
+    assert.True(t, model.HasFieldType())
+    assert.Equal(t, exampleParamField, model.GetFieldType())
+
+    model.SetGroup(exampleParamGroup)
+    assert.True(t, model.HasGroup())
+    assert.Equal(t, exampleParamGroup, model.GetGroup())
+
+    model.SetLabel(exampleParamLabel)
+    assert.True(t, model.HasLabel())
+    assert.Equal(t, exampleParamLabel, model.GetLabel())
+
+    model.SetLocked(exampleParamLocked)
+    assert.True(t, model.HasLocked())
+    assert.Equal(t, exampleParamLocked, model.GetLocked())
+
+    model.SetOrder(exampleParamOrder)
+    assert.True(t, model.HasOrder())
+    assert.Equal(t, exampleParamOrder, model.GetOrder())
+
+    model.SetPattern(exampleParamPattern)
+    assert.True(t, model.HasPattern())
+    assert.Equal(t, exampleParamPattern, model.GetPattern())
+
+    model.SetPlaceholder(exampleParamPlaceholder)
+    assert.True(t, model.HasPlaceholder())
+    assert.Equal(t, exampleParamPlaceholder, model.GetPlaceholder())
+
+    model.SetRequired(exampleParamRequired)
+    assert.True(t, model.HasRequired())
+    assert.Equal(t, exampleParamRequired, model.GetRequired())
+
+    model.SetValue(exampleParamValue)
+    assert.True(t, model.HasValue())
+    assert.Equal(t, exampleParamValue, model.GetValue())
+}
+
+func TestPaylinkCustomParamJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkCustomParam()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkCustomParam
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasOrder())
+    assert.Equal(t, exampleParamOrder, unmarshalled.GetOrder())
+}
+
+func TestPaylinkCustomParamToMap(t *testing.T) {
+    model := buildExamplePaylinkCustomParam()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleParamName, m["name"])
+    if assert.Contains(t, m, "value") {
+        assert.Equal(t, &exampleParamValue, m["value"])
+    }
+}
+
+func TestNullablePaylinkCustomParamGetSet(t *testing.T) {
+    base := buildExamplePaylinkCustomParam()
+    n := openapiclient.NullablePaylinkCustomParam{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkCustomParamUnset(t *testing.T) {
+    base := buildExamplePaylinkCustomParam()
+    n := openapiclient.NewNullablePaylinkCustomParam(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkCustomParamJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkCustomParam()
+    n := openapiclient.NewNullablePaylinkCustomParam(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkCustomParam
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleParamName, newN.Get().GetName())
+    }
+}
+

--- a/test/model/model_paylink_email_notification_path_test.go
+++ b/test/model/model_paylink_email_notification_path_test.go
@@ -1,0 +1,111 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleEmailBCC = []string{"b@example.com"}
+var exampleEmailCC = []string{"c@example.com"}
+var exampleEmailReply = []string{"r@example.com"}
+var exampleEmailTemplate = "tmpl"
+var exampleEmailTo = []string{"to@example.com"}
+
+func buildExamplePaylinkEmailNotificationPath() openapiclient.PaylinkEmailNotificationPath {
+    p := openapiclient.NewPaylinkEmailNotificationPath(exampleEmailTo)
+    p.SetBcc(exampleEmailBCC)
+    p.SetCc(exampleEmailCC)
+    p.SetReplyTo(exampleEmailReply)
+    p.SetTemplate(exampleEmailTemplate)
+    return *p
+}
+
+func TestNewPaylinkEmailNotificationPath(t *testing.T) {
+    model := openapiclient.NewPaylinkEmailNotificationPath(exampleEmailTo)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleEmailTo, model.GetTo())
+    assert.False(t, model.HasBcc())
+}
+
+func TestNewPaylinkEmailNotificationPathWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkEmailNotificationPathWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasTemplate())
+}
+
+func TestPaylinkEmailNotificationPathSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkEmailNotificationPath(exampleEmailTo)
+    model.SetBcc(exampleEmailBCC)
+    assert.True(t, model.HasBcc())
+    assert.Equal(t, exampleEmailBCC, model.GetBcc())
+
+    model.SetCc(exampleEmailCC)
+    assert.True(t, model.HasCc())
+    assert.Equal(t, exampleEmailCC, model.GetCc())
+
+    model.SetReplyTo(exampleEmailReply)
+    assert.True(t, model.HasReplyTo())
+    assert.Equal(t, exampleEmailReply, model.GetReplyTo())
+
+    model.SetTemplate(exampleEmailTemplate)
+    assert.True(t, model.HasTemplate())
+    assert.Equal(t, exampleEmailTemplate, model.GetTemplate())
+}
+
+func TestPaylinkEmailNotificationPathJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkEmailNotificationPath()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkEmailNotificationPath
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasBcc())
+    assert.Equal(t, exampleEmailBCC, unmarshalled.GetBcc())
+}
+
+func TestPaylinkEmailNotificationPathToMap(t *testing.T) {
+    model := buildExamplePaylinkEmailNotificationPath()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "bcc") {
+        assert.Equal(t, exampleEmailBCC, m["bcc"])
+    }
+    assert.Equal(t, exampleEmailTo, m["to"])
+}
+
+func TestNullablePaylinkEmailNotificationPathGetSet(t *testing.T) {
+    base := buildExamplePaylinkEmailNotificationPath()
+    n := openapiclient.NullablePaylinkEmailNotificationPath{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkEmailNotificationPathUnset(t *testing.T) {
+    base := buildExamplePaylinkEmailNotificationPath()
+    n := openapiclient.NewNullablePaylinkEmailNotificationPath(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkEmailNotificationPathJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkEmailNotificationPath()
+    n := openapiclient.NewNullablePaylinkEmailNotificationPath(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkEmailNotificationPath
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleEmailTemplate, newN.Get().GetTemplate())
+    }
+}
+

--- a/test/model/model_paylink_error_code_test.go
+++ b/test/model/model_paylink_error_code_test.go
@@ -1,0 +1,91 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleErrCode = "E1"
+var exampleErrMsg = "error"
+
+func buildExamplePaylinkErrorCode() openapiclient.PaylinkErrorCode {
+    e := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
+    return *e
+}
+
+func TestNewPaylinkErrorCode(t *testing.T) {
+    model := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleErrCode, model.GetCode())
+    assert.Equal(t, exampleErrMsg, model.GetMsg())
+}
+
+func TestNewPaylinkErrorCodeWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkErrorCodeWithDefaults()
+    require.NotNil(t, model)
+    assert.NotNil(t, model)
+}
+
+func TestPaylinkErrorCodeSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
+    model.SetCode("E2")
+    assert.Equal(t, "E2", model.GetCode())
+
+    model.SetMsg("msg")
+    assert.Equal(t, "msg", model.GetMsg())
+}
+
+func TestPaylinkErrorCodeJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkErrorCode()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkErrorCode
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleErrMsg, unmarshalled.GetMsg())
+}
+
+func TestPaylinkErrorCodeToMap(t *testing.T) {
+    model := buildExamplePaylinkErrorCode()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleErrCode, m["code"])
+    assert.Equal(t, exampleErrMsg, m["msg"])
+}
+
+func TestNullablePaylinkErrorCodeGetSet(t *testing.T) {
+    base := buildExamplePaylinkErrorCode()
+    n := openapiclient.NullablePaylinkErrorCode{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkErrorCodeUnset(t *testing.T) {
+    base := buildExamplePaylinkErrorCode()
+    n := openapiclient.NewNullablePaylinkErrorCode(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkErrorCodeJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkErrorCode()
+    n := openapiclient.NewNullablePaylinkErrorCode(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkErrorCode
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleErrCode, newN.Get().GetCode())
+    }
+}
+

--- a/test/model/model_paylink_field_guard_model_test.go
+++ b/test/model/model_paylink_field_guard_model_test.go
@@ -1,0 +1,126 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleFGField = "text"
+var exampleFGLabel = "Security"
+var exampleFGMax int32 = 8
+var exampleFGMin int32 = 2
+var exampleFGName = "pin"
+var exampleFGRegex = "\\d+"
+var exampleFGValue = "12"
+
+func buildExamplePaylinkFieldGuardModel() openapiclient.PaylinkFieldGuardModel {
+    f := openapiclient.NewPaylinkFieldGuardModel()
+    f.SetFieldType(exampleFGField)
+    f.SetLabel(exampleFGLabel)
+    f.SetMaxlen(exampleFGMax)
+    f.SetMinlen(exampleFGMin)
+    f.SetName(exampleFGName)
+    f.SetRegex(exampleFGRegex)
+    f.SetValue(exampleFGValue)
+    return *f
+}
+
+func TestNewPaylinkFieldGuardModel(t *testing.T) {
+    model := openapiclient.NewPaylinkFieldGuardModel()
+    require.NotNil(t, model)
+    assert.False(t, model.HasFieldType())
+}
+
+func TestNewPaylinkFieldGuardModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkFieldGuardModelWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasName())
+}
+
+func TestPaylinkFieldGuardModelSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkFieldGuardModel()
+    model.SetFieldType(exampleFGField)
+    assert.True(t, model.HasFieldType())
+    assert.Equal(t, exampleFGField, model.GetFieldType())
+
+    model.SetLabel(exampleFGLabel)
+    assert.True(t, model.HasLabel())
+    assert.Equal(t, exampleFGLabel, model.GetLabel())
+
+    model.SetMaxlen(exampleFGMax)
+    assert.True(t, model.HasMaxlen())
+    assert.Equal(t, exampleFGMax, model.GetMaxlen())
+
+    model.SetMinlen(exampleFGMin)
+    assert.True(t, model.HasMinlen())
+    assert.Equal(t, exampleFGMin, model.GetMinlen())
+
+    model.SetName(exampleFGName)
+    assert.True(t, model.HasName())
+    assert.Equal(t, exampleFGName, model.GetName())
+
+    model.SetRegex(exampleFGRegex)
+    assert.True(t, model.HasRegex())
+    assert.Equal(t, exampleFGRegex, model.GetRegex())
+
+    model.SetValue(exampleFGValue)
+    assert.True(t, model.HasValue())
+    assert.Equal(t, exampleFGValue, model.GetValue())
+}
+
+func TestPaylinkFieldGuardModelJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkFieldGuardModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkFieldGuardModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasName())
+    assert.Equal(t, exampleFGName, unmarshalled.GetName())
+}
+
+func TestPaylinkFieldGuardModelToMap(t *testing.T) {
+    model := buildExamplePaylinkFieldGuardModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "regex") {
+        assert.Equal(t, &exampleFGRegex, m["regex"])
+    }
+}
+
+func TestNullablePaylinkFieldGuardModelGetSet(t *testing.T) {
+    base := buildExamplePaylinkFieldGuardModel()
+    n := openapiclient.NullablePaylinkFieldGuardModel{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkFieldGuardModelUnset(t *testing.T) {
+    base := buildExamplePaylinkFieldGuardModel()
+    n := openapiclient.NewNullablePaylinkFieldGuardModel(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkFieldGuardModelJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkFieldGuardModel()
+    n := openapiclient.NewNullablePaylinkFieldGuardModel(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkFieldGuardModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleFGMin, newN.Get().GetMinlen())
+    }
+}
+

--- a/test/model/model_paylink_part_payments_test.go
+++ b/test/model/model_paylink_part_payments_test.go
@@ -1,0 +1,123 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var examplePartEnabled = "true"
+var examplePartFloor = "5"
+var examplePartMax = "90"
+var examplePartMaxRate = "10%"
+var examplePartMin = "10"
+var examplePartMinRate = "5%"
+
+func buildExamplePaylinkPartPayments() openapiclient.PaylinkPartPayments {
+    p := openapiclient.NewPaylinkPartPayments()
+    p.SetEnabled(examplePartEnabled)
+    p.SetFloor(examplePartFloor)
+    p.SetMax(examplePartMax)
+    p.SetMaxRate(examplePartMaxRate)
+    p.SetMin(examplePartMin)
+    p.SetMinRate(examplePartMinRate)
+    return *p
+}
+
+func TestNewPaylinkPartPayments(t *testing.T) {
+    model := openapiclient.NewPaylinkPartPayments()
+    require.NotNil(t, model)
+    assert.False(t, model.HasEnabled())
+}
+
+func TestNewPaylinkPartPaymentsWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkPartPaymentsWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasFloor())
+}
+
+func TestPaylinkPartPaymentsSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkPartPayments()
+    model.SetEnabled(examplePartEnabled)
+    assert.True(t, model.HasEnabled())
+    assert.Equal(t, examplePartEnabled, model.GetEnabled())
+
+    model.SetFloor(examplePartFloor)
+    assert.True(t, model.HasFloor())
+    assert.Equal(t, examplePartFloor, model.GetFloor())
+
+    model.SetMax(examplePartMax)
+    assert.True(t, model.HasMax())
+    assert.Equal(t, examplePartMax, model.GetMax())
+
+    model.SetMaxRate(examplePartMaxRate)
+    assert.True(t, model.HasMaxRate())
+    assert.Equal(t, examplePartMaxRate, model.GetMaxRate())
+
+    model.SetMin(examplePartMin)
+    assert.True(t, model.HasMin())
+    assert.Equal(t, examplePartMin, model.GetMin())
+
+    model.SetMinRate(examplePartMinRate)
+    assert.True(t, model.HasMinRate())
+    assert.Equal(t, examplePartMinRate, model.GetMinRate())
+}
+
+func TestPaylinkPartPaymentsJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkPartPayments()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkPartPayments
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasFloor())
+    assert.Equal(t, examplePartFloor, unmarshalled.GetFloor())
+}
+
+func TestPaylinkPartPaymentsToMap(t *testing.T) {
+    model := buildExamplePaylinkPartPayments()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "enabled") {
+        assert.Equal(t, &examplePartEnabled, m["enabled"])
+    }
+    if assert.Contains(t, m, "max_rate") {
+        assert.Equal(t, &examplePartMaxRate, m["max_rate"])
+    }
+}
+
+func TestNullablePaylinkPartPaymentsGetSet(t *testing.T) {
+    base := buildExamplePaylinkPartPayments()
+    n := openapiclient.NullablePaylinkPartPayments{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkPartPaymentsUnset(t *testing.T) {
+    base := buildExamplePaylinkPartPayments()
+    n := openapiclient.NewNullablePaylinkPartPayments(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkPartPaymentsJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkPartPayments()
+    n := openapiclient.NewNullablePaylinkPartPayments(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkPartPayments
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, examplePartMax, newN.Get().GetMax())
+    }
+}
+

--- a/test/model/model_paylink_resend_notification_request_test.go
+++ b/test/model/model_paylink_resend_notification_request_test.go
@@ -1,0 +1,99 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleResendEmail = true
+var exampleResendSms = true
+
+func buildExamplePaylinkResendNotificationRequest() openapiclient.PaylinkResendNotificationRequest {
+    r := openapiclient.NewPaylinkResendNotificationRequest()
+    r.SetEmail(exampleResendEmail)
+    r.SetSms(exampleResendSms)
+    return *r
+}
+
+func TestNewPaylinkResendNotificationRequest(t *testing.T) {
+    model := openapiclient.NewPaylinkResendNotificationRequest()
+    require.NotNil(t, model)
+    assert.False(t, model.HasEmail())
+}
+
+func TestNewPaylinkResendNotificationRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkResendNotificationRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasSms())
+}
+
+func TestPaylinkResendNotificationRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkResendNotificationRequest()
+    model.SetEmail(exampleResendEmail)
+    assert.True(t, model.HasEmail())
+    assert.Equal(t, exampleResendEmail, model.GetEmail())
+
+    model.SetSms(exampleResendSms)
+    assert.True(t, model.HasSms())
+    assert.Equal(t, exampleResendSms, model.GetSms())
+}
+
+func TestPaylinkResendNotificationRequestJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkResendNotificationRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkResendNotificationRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasEmail())
+    assert.Equal(t, exampleResendEmail, unmarshalled.GetEmail())
+}
+
+func TestPaylinkResendNotificationRequestToMap(t *testing.T) {
+    model := buildExamplePaylinkResendNotificationRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "email") {
+        assert.Equal(t, &exampleResendEmail, m["email"])
+    }
+    if assert.Contains(t, m, "sms") {
+        assert.Equal(t, &exampleResendSms, m["sms"])
+    }
+}
+
+func TestNullablePaylinkResendNotificationRequestGetSet(t *testing.T) {
+    base := buildExamplePaylinkResendNotificationRequest()
+    n := openapiclient.NullablePaylinkResendNotificationRequest{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkResendNotificationRequestUnset(t *testing.T) {
+    base := buildExamplePaylinkResendNotificationRequest()
+    n := openapiclient.NewNullablePaylinkResendNotificationRequest(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkResendNotificationRequestJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkResendNotificationRequest()
+    n := openapiclient.NewNullablePaylinkResendNotificationRequest(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkResendNotificationRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleResendSms, newN.Get().GetSms())
+    }
+}
+

--- a/test/model/model_paylink_sms_notification_path_test.go
+++ b/test/model/model_paylink_sms_notification_path_test.go
@@ -1,0 +1,93 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleSmsTemplate = "tpl"
+var exampleSmsTo = "+4411111"
+
+func buildExamplePaylinkSMSNotificationPath() openapiclient.PaylinkSMSNotificationPath {
+    p := openapiclient.NewPaylinkSMSNotificationPath(exampleSmsTo)
+    p.SetTemplate(exampleSmsTemplate)
+    return *p
+}
+
+func TestNewPaylinkSMSNotificationPath(t *testing.T) {
+    model := openapiclient.NewPaylinkSMSNotificationPath(exampleSmsTo)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleSmsTo, model.GetTo())
+    assert.False(t, model.HasTemplate())
+}
+
+func TestNewPaylinkSMSNotificationPathWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkSMSNotificationPathWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasTemplate())
+}
+
+func TestPaylinkSMSNotificationPathSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkSMSNotificationPath(exampleSmsTo)
+    model.SetTemplate(exampleSmsTemplate)
+    assert.True(t, model.HasTemplate())
+    assert.Equal(t, exampleSmsTemplate, model.GetTemplate())
+}
+
+func TestPaylinkSMSNotificationPathJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkSMSNotificationPath()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkSMSNotificationPath
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasTemplate())
+    assert.Equal(t, exampleSmsTemplate, unmarshalled.GetTemplate())
+}
+
+func TestPaylinkSMSNotificationPathToMap(t *testing.T) {
+    model := buildExamplePaylinkSMSNotificationPath()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleSmsTo, m["to"])
+    if assert.Contains(t, m, "template") {
+        assert.Equal(t, &exampleSmsTemplate, m["template"])
+    }
+}
+
+func TestNullablePaylinkSMSNotificationPathGetSet(t *testing.T) {
+    base := buildExamplePaylinkSMSNotificationPath()
+    n := openapiclient.NullablePaylinkSMSNotificationPath{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkSMSNotificationPathUnset(t *testing.T) {
+    base := buildExamplePaylinkSMSNotificationPath()
+    n := openapiclient.NewNullablePaylinkSMSNotificationPath(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkSMSNotificationPathJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkSMSNotificationPath()
+    n := openapiclient.NewNullablePaylinkSMSNotificationPath(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkSMSNotificationPath
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleSmsTo, newN.Get().GetTo())
+    }
+}
+

--- a/test/model/model_paylink_state_event_test.go
+++ b/test/model/model_paylink_state_event_test.go
@@ -1,0 +1,103 @@
+package citypay
+
+import (
+    "encoding/json"
+    "time"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleEventDate = time.Date(2024, time.March, 1, 0, 0, 0, 0, time.UTC)
+var exampleEventMessage = "msg"
+var exampleEventState = "CREATED"
+
+func buildExamplePaylinkStateEvent() openapiclient.PaylinkStateEvent {
+    e := openapiclient.NewPaylinkStateEvent()
+    e.SetDatetime(exampleEventDate)
+    e.SetMessage(exampleEventMessage)
+    e.SetState(exampleEventState)
+    return *e
+}
+
+func TestNewPaylinkStateEvent(t *testing.T) {
+    model := openapiclient.NewPaylinkStateEvent()
+    require.NotNil(t, model)
+    assert.False(t, model.HasState())
+}
+
+func TestNewPaylinkStateEventWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkStateEventWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasMessage())
+}
+
+func TestPaylinkStateEventSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkStateEvent()
+    model.SetDatetime(exampleEventDate)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleEventDate, model.GetDatetime())
+
+    model.SetMessage(exampleEventMessage)
+    assert.True(t, model.HasMessage())
+    assert.Equal(t, exampleEventMessage, model.GetMessage())
+
+    model.SetState(exampleEventState)
+    assert.True(t, model.HasState())
+    assert.Equal(t, exampleEventState, model.GetState())
+}
+
+func TestPaylinkStateEventJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkStateEvent()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkStateEvent
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasState())
+    assert.Equal(t, exampleEventState, unmarshalled.GetState())
+}
+
+func TestPaylinkStateEventToMap(t *testing.T) {
+    model := buildExamplePaylinkStateEvent()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "message") {
+        assert.Equal(t, &exampleEventMessage, m["message"])
+    }
+}
+
+func TestNullablePaylinkStateEventGetSet(t *testing.T) {
+    base := buildExamplePaylinkStateEvent()
+    n := openapiclient.NullablePaylinkStateEvent{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkStateEventUnset(t *testing.T) {
+    base := buildExamplePaylinkStateEvent()
+    n := openapiclient.NewNullablePaylinkStateEvent(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkStateEventJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkStateEvent()
+    n := openapiclient.NewNullablePaylinkStateEvent(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkStateEvent
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleEventState, newN.Get().GetState())
+    }
+}
+

--- a/test/model/model_paylink_token_created_test.go
+++ b/test/model/model_paylink_token_created_test.go
@@ -1,0 +1,168 @@
+package citypay
+
+import (
+    "encoding/json"
+    "time"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleTokenId = "id"
+var exampleTokenResult int32 = 1
+var exampleTokenToken = "tok"
+var exampleTokenBps = "Y"
+var exampleTokenDate = time.Date(2024, time.July, 1, 0, 0, 0, 0, time.UTC)
+var exampleTokenIdentifier = "ident"
+var exampleTokenMode = "test"
+var exampleTokenQrcode = "https://q"
+var exampleTokenServer = "v1"
+var exampleTokenSource = "1.1.1.1"
+var exampleTokenURL = "https://u"
+var exampleTokenUsc = "usc"
+
+func buildExampleAttachmentRes() openapiclient.PaylinkAttachmentResult {
+    a := openapiclient.NewPaylinkAttachmentResult("name", "OK")
+    return *a
+}
+
+func buildExampleErrorCode() openapiclient.PaylinkErrorCode {
+    e := openapiclient.NewPaylinkErrorCode("E", "m")
+    return *e
+}
+
+func buildExamplePaylinkTokenCreated() openapiclient.PaylinkTokenCreated {
+    t := openapiclient.NewPaylinkTokenCreated(exampleTokenId, exampleTokenResult, exampleTokenToken)
+    t.SetAttachments(buildExampleAttachmentRes())
+    t.SetBps(exampleTokenBps)
+    t.SetDateCreated(exampleTokenDate)
+    t.SetErrors([]openapiclient.PaylinkErrorCode{buildExampleErrorCode()})
+    t.SetIdentifier(exampleTokenIdentifier)
+    t.SetMode(exampleTokenMode)
+    t.SetQrcode(exampleTokenQrcode)
+    t.SetServerVersion(exampleTokenServer)
+    t.SetSource(exampleTokenSource)
+    t.SetUrl(exampleTokenURL)
+    t.SetUsc(exampleTokenUsc)
+    return *t
+}
+
+func TestNewPaylinkTokenCreated(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenCreated(exampleTokenId, exampleTokenResult, exampleTokenToken)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleTokenId, model.GetId())
+    assert.Equal(t, exampleTokenResult, model.GetResult())
+    assert.Equal(t, exampleTokenToken, model.GetToken())
+    assert.False(t, model.HasMode())
+}
+
+func TestNewPaylinkTokenCreatedWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenCreatedWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasResult())
+}
+
+func TestPaylinkTokenCreatedSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenCreated(exampleTokenId, exampleTokenResult, exampleTokenToken)
+    att := buildExampleAttachmentRes()
+    model.SetAttachments(att)
+    assert.True(t, model.HasAttachments())
+    assert.Equal(t, att, model.GetAttachments())
+
+    model.SetBps(exampleTokenBps)
+    assert.True(t, model.HasBps())
+    assert.Equal(t, exampleTokenBps, model.GetBps())
+
+    model.SetDateCreated(exampleTokenDate)
+    assert.True(t, model.HasDateCreated())
+    assert.Equal(t, exampleTokenDate, model.GetDateCreated())
+
+    errs := []openapiclient.PaylinkErrorCode{buildExampleErrorCode()}
+    model.SetErrors(errs)
+    assert.True(t, model.HasErrors())
+    assert.Len(t, model.GetErrors(), 1)
+
+    model.SetIdentifier(exampleTokenIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleTokenIdentifier, model.GetIdentifier())
+
+    model.SetMode(exampleTokenMode)
+    assert.True(t, model.HasMode())
+    assert.Equal(t, exampleTokenMode, model.GetMode())
+
+    model.SetQrcode(exampleTokenQrcode)
+    assert.True(t, model.HasQrcode())
+    assert.Equal(t, exampleTokenQrcode, model.GetQrcode())
+
+    model.SetServerVersion(exampleTokenServer)
+    assert.True(t, model.HasServerVersion())
+    assert.Equal(t, exampleTokenServer, model.GetServerVersion())
+
+    model.SetSource(exampleTokenSource)
+    assert.True(t, model.HasSource())
+    assert.Equal(t, exampleTokenSource, model.GetSource())
+
+    model.SetUrl(exampleTokenURL)
+    assert.True(t, model.HasUrl())
+    assert.Equal(t, exampleTokenURL, model.GetUrl())
+
+    model.SetUsc(exampleTokenUsc)
+    assert.True(t, model.HasUsc())
+    assert.Equal(t, exampleTokenUsc, model.GetUsc())
+}
+
+func TestPaylinkTokenCreatedJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkTokenCreated()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkTokenCreated
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.Equal(t, exampleTokenResult, unmarshalled.GetResult())
+    assert.True(t, unmarshalled.HasUrl())
+}
+
+func TestPaylinkTokenCreatedToMap(t *testing.T) {
+    model := buildExamplePaylinkTokenCreated()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleTokenId, m["id"])
+    if assert.Contains(t, m, "usc") {
+        assert.Equal(t, &exampleTokenUsc, m["usc"])
+    }
+}
+
+func TestNullablePaylinkTokenCreatedGetSet(t *testing.T) {
+    base := buildExamplePaylinkTokenCreated()
+    n := openapiclient.NullablePaylinkTokenCreated{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkTokenCreatedUnset(t *testing.T) {
+    base := buildExamplePaylinkTokenCreated()
+    n := openapiclient.NewNullablePaylinkTokenCreated(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkTokenCreatedJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkTokenCreated()
+    n := openapiclient.NewNullablePaylinkTokenCreated(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkTokenCreated
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleTokenUsc, newN.Get().GetUsc())
+    }
+}
+

--- a/test/model/model_paylink_token_request_model_test.go
+++ b/test/model/model_paylink_token_request_model_test.go
@@ -1,0 +1,167 @@
+package citypay
+
+import (
+    "encoding/json"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleReqAccount = "acc"
+var exampleReqAmount int32 = 100
+var exampleReqIdentifier = "id"
+var exampleReqMerchant int32 = 1
+var exampleReqClientVersion = "1.0"
+var exampleReqCurrency = "GBP"
+var exampleReqEmail = "m@example.com"
+var exampleReqRecurring = true
+var exampleReqSub = "sub"
+var exampleReqTxType = "SALE"
+
+func buildExampleCardHolder() openapiclient.PaylinkCardHolder {
+    c := openapiclient.NewPaylinkCardHolder()
+    c.SetFirstname("f")
+    return *c
+}
+
+func buildExampleCart() openapiclient.PaylinkCart {
+    c := openapiclient.NewPaylinkCart()
+    return *c
+}
+
+func buildExampleConfig() openapiclient.PaylinkConfig {
+    c := openapiclient.NewPaylinkConfig()
+    return *c
+}
+
+func buildExamplePaylinkTokenRequestModel() openapiclient.PaylinkTokenRequestModel {
+    r := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
+    r.SetAccountno(exampleReqAccount)
+    ch := buildExampleCardHolder()
+    r.SetCardholder(ch)
+    cart := buildExampleCart()
+    r.SetCart(cart)
+    r.SetClientVersion(exampleReqClientVersion)
+    cfg := buildExampleConfig()
+    r.SetConfig(cfg)
+    r.SetCurrency(exampleReqCurrency)
+    r.SetEmail(exampleReqEmail)
+    r.SetRecurring(exampleReqRecurring)
+    r.SetSubscriptionId(exampleReqSub)
+    r.SetTxType(exampleReqTxType)
+    return *r
+}
+
+func TestNewPaylinkTokenRequestModel(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleReqAmount, model.GetAmount())
+    assert.Equal(t, exampleReqIdentifier, model.GetIdentifier())
+    assert.Equal(t, exampleReqMerchant, model.GetMerchantid())
+    assert.False(t, model.HasEmail())
+}
+
+func TestNewPaylinkTokenRequestModelWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenRequestModelWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasAmount())
+}
+
+func TestPaylinkTokenRequestModelSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
+    model.SetAccountno(exampleReqAccount)
+    assert.True(t, model.HasAccountno())
+    assert.Equal(t, exampleReqAccount, model.GetAccountno())
+
+    ch := buildExampleCardHolder()
+    model.SetCardholder(ch)
+    assert.True(t, model.HasCardholder())
+
+    cart := buildExampleCart()
+    model.SetCart(cart)
+    assert.True(t, model.HasCart())
+
+    model.SetClientVersion(exampleReqClientVersion)
+    assert.True(t, model.HasClientVersion())
+    assert.Equal(t, exampleReqClientVersion, model.GetClientVersion())
+
+    cfg := buildExampleConfig()
+    model.SetConfig(cfg)
+    assert.True(t, model.HasConfig())
+
+    model.SetCurrency(exampleReqCurrency)
+    assert.True(t, model.HasCurrency())
+    assert.Equal(t, exampleReqCurrency, model.GetCurrency())
+
+    model.SetEmail(exampleReqEmail)
+    assert.True(t, model.HasEmail())
+    assert.Equal(t, exampleReqEmail, model.GetEmail())
+
+    model.SetRecurring(exampleReqRecurring)
+    assert.True(t, model.HasRecurring())
+    assert.Equal(t, exampleReqRecurring, model.GetRecurring())
+
+    model.SetSubscriptionId(exampleReqSub)
+    assert.True(t, model.HasSubscriptionId())
+    assert.Equal(t, exampleReqSub, model.GetSubscriptionId())
+
+    model.SetTxType(exampleReqTxType)
+    assert.True(t, model.HasTxType())
+    assert.Equal(t, exampleReqTxType, model.GetTxType())
+}
+
+func TestPaylinkTokenRequestModelJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkTokenRequestModel()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkTokenRequestModel
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasAccountno())
+    assert.Equal(t, exampleReqAccount, unmarshalled.GetAccountno())
+}
+
+func TestPaylinkTokenRequestModelToMap(t *testing.T) {
+    model := buildExamplePaylinkTokenRequestModel()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleReqAmount, m["amount"])
+    if assert.Contains(t, m, "tx_type") {
+        assert.Equal(t, &exampleReqTxType, m["tx_type"])
+    }
+}
+
+func TestNullablePaylinkTokenRequestModelGetSet(t *testing.T) {
+    base := buildExamplePaylinkTokenRequestModel()
+    n := openapiclient.NullablePaylinkTokenRequestModel{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkTokenRequestModelUnset(t *testing.T) {
+    base := buildExamplePaylinkTokenRequestModel()
+    n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkTokenRequestModelJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkTokenRequestModel()
+    n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkTokenRequestModel
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleReqMerchant, newN.Get().GetMerchantid())
+    }
+}
+

--- a/test/model/model_paylink_token_status_change_request_test.go
+++ b/test/model/model_paylink_token_status_change_request_test.go
@@ -1,0 +1,108 @@
+package citypay
+
+import (
+    "encoding/json"
+    "time"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleChangeAfter = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+var exampleChangeMax int32 = 10
+var exampleChangeMerchant int32 = 1
+var exampleChangeNext = "nxt"
+var exampleChangeOrder = "p.id"
+
+func buildExamplePaylinkTokenStatusChangeRequest() openapiclient.PaylinkTokenStatusChangeRequest {
+    r := openapiclient.NewPaylinkTokenStatusChangeRequest(exampleChangeAfter, exampleChangeMerchant)
+    r.SetMaxResults(exampleChangeMax)
+    r.SetNextToken(exampleChangeNext)
+    r.SetOrderBy(exampleChangeOrder)
+    return *r
+}
+
+func TestNewPaylinkTokenStatusChangeRequest(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatusChangeRequest(exampleChangeAfter, exampleChangeMerchant)
+    require.NotNil(t, model)
+    assert.Equal(t, exampleChangeAfter, model.GetAfter())
+    assert.Equal(t, exampleChangeMerchant, model.GetMerchantid())
+    assert.False(t, model.HasMaxResults())
+}
+
+func TestNewPaylinkTokenStatusChangeRequestWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatusChangeRequestWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasNextToken())
+}
+
+func TestPaylinkTokenStatusChangeRequestSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatusChangeRequest(exampleChangeAfter, exampleChangeMerchant)
+    model.SetMaxResults(exampleChangeMax)
+    assert.True(t, model.HasMaxResults())
+    assert.Equal(t, exampleChangeMax, model.GetMaxResults())
+
+    model.SetNextToken(exampleChangeNext)
+    assert.True(t, model.HasNextToken())
+    assert.Equal(t, exampleChangeNext, model.GetNextToken())
+
+    model.SetOrderBy(exampleChangeOrder)
+    assert.True(t, model.HasOrderBy())
+    assert.Equal(t, exampleChangeOrder, model.GetOrderBy())
+}
+
+func TestPaylinkTokenStatusChangeRequestJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkTokenStatusChangeRequest()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkTokenStatusChangeRequest
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasMaxResults())
+    assert.Equal(t, exampleChangeMax, unmarshalled.GetMaxResults())
+}
+
+func TestPaylinkTokenStatusChangeRequestToMap(t *testing.T) {
+    model := buildExamplePaylinkTokenStatusChangeRequest()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    assert.Equal(t, exampleChangeAfter, m["after"])
+    if assert.Contains(t, m, "nextToken") {
+        assert.Equal(t, &exampleChangeNext, m["nextToken"])
+    }
+}
+
+func TestNullablePaylinkTokenStatusChangeRequestGetSet(t *testing.T) {
+    base := buildExamplePaylinkTokenStatusChangeRequest()
+    n := openapiclient.NullablePaylinkTokenStatusChangeRequest{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusChangeRequestUnset(t *testing.T) {
+    base := buildExamplePaylinkTokenStatusChangeRequest()
+    n := openapiclient.NewNullablePaylinkTokenStatusChangeRequest(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusChangeRequestJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkTokenStatusChangeRequest()
+    n := openapiclient.NewNullablePaylinkTokenStatusChangeRequest(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkTokenStatusChangeRequest
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleChangeMerchant, newN.Get().GetMerchantid())
+    }
+}
+

--- a/test/model/model_paylink_token_status_change_response_test.go
+++ b/test/model/model_paylink_token_status_change_response_test.go
@@ -1,0 +1,108 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleChangeRespCount int32 = 2
+var exampleChangeRespMax int32 = 10
+var exampleChangeRespNext = "nxt"
+
+func buildExamplePaylinkTokenStatusChangeResponse() openapiclient.PaylinkTokenStatusChangeResponse {
+	tok := buildExamplePaylinkTokenStatus()
+	r := openapiclient.NewPaylinkTokenStatusChangeResponse([]openapiclient.PaylinkTokenStatus{tok})
+	r.SetCount(exampleChangeRespCount)
+	r.SetMaxResults(exampleChangeRespMax)
+	r.SetNextToken(exampleChangeRespNext)
+	return *r
+}
+
+func TestNewPaylinkTokenStatusChangeResponse(t *testing.T) {
+	model := openapiclient.NewPaylinkTokenStatusChangeResponse([]openapiclient.PaylinkTokenStatus{})
+	require.NotNil(t, model)
+	assert.NotNil(t, model.GetTokens())
+	assert.False(t, model.HasCount())
+}
+
+func TestNewPaylinkTokenStatusChangeResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaylinkTokenStatusChangeResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasMaxResults())
+}
+
+func TestPaylinkTokenStatusChangeResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaylinkTokenStatusChangeResponse([]openapiclient.PaylinkTokenStatus{})
+	model.SetCount(exampleChangeRespCount)
+	assert.True(t, model.HasCount())
+	assert.Equal(t, exampleChangeRespCount, model.GetCount())
+
+	model.SetMaxResults(exampleChangeRespMax)
+	assert.True(t, model.HasMaxResults())
+	assert.Equal(t, exampleChangeRespMax, model.GetMaxResults())
+
+	model.SetNextToken(exampleChangeRespNext)
+	assert.True(t, model.HasNextToken())
+	assert.Equal(t, exampleChangeRespNext, model.GetNextToken())
+
+	tok := buildExamplePaylinkTokenStatus()
+	model.SetTokens([]openapiclient.PaylinkTokenStatus{tok})
+	assert.Len(t, model.GetTokens(), 1)
+}
+
+func TestPaylinkTokenStatusChangeResponseJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaylinkTokenStatusChangeResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaylinkTokenStatusChangeResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCount())
+	assert.Equal(t, exampleChangeRespCount, unmarshalled.GetCount())
+}
+
+func TestPaylinkTokenStatusChangeResponseToMap(t *testing.T) {
+	model := buildExamplePaylinkTokenStatusChangeResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "nextToken") {
+		assert.Equal(t, &exampleChangeRespNext, m["nextToken"])
+	}
+	assert.Contains(t, m, "tokens")
+}
+
+func TestNullablePaylinkTokenStatusChangeResponseGetSet(t *testing.T) {
+	base := buildExamplePaylinkTokenStatusChangeResponse()
+	n := openapiclient.NullablePaylinkTokenStatusChangeResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusChangeResponseUnset(t *testing.T) {
+	base := buildExamplePaylinkTokenStatusChangeResponse()
+	n := openapiclient.NewNullablePaylinkTokenStatusChangeResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusChangeResponseJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaylinkTokenStatusChangeResponse()
+	n := openapiclient.NewNullablePaylinkTokenStatusChangeResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaylinkTokenStatusChangeResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleChangeRespMax, newN.Get().GetMaxResults())
+	}
+}

--- a/test/model/model_paylink_token_status_test.go
+++ b/test/model/model_paylink_token_status_test.go
@@ -1,0 +1,157 @@
+package citypay
+
+import (
+    "encoding/json"
+    "time"
+    openapiclient "github.com/citypay/citypay-api-client-go"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+    "testing"
+)
+
+var exampleStatusAmount int32 = 100
+var exampleStatusAuthCode = "AUTH"
+var exampleStatusCard = "VISA"
+var exampleStatusCreated = time.Date(2024, time.April, 1, 0, 0, 0, 0, time.UTC)
+var exampleStatusDatetime = time.Date(2024, time.April, 2, 0, 0, 0, 0, time.UTC)
+var exampleStatusIdentifier = "id"
+var exampleStatusIsPaid = true
+var exampleStatusMid int32 = 2
+var exampleStatusToken = "tok"
+var exampleStatusTransNo int32 = 5
+
+func buildExamplePaylinkStateEventSlice() []openapiclient.PaylinkStateEvent {
+    e := openapiclient.NewPaylinkStateEvent()
+    e.SetState("CREATED")
+    return []openapiclient.PaylinkStateEvent{*e}
+}
+
+func buildExamplePaylinkTokenStatus() openapiclient.PaylinkTokenStatus {
+    s := openapiclient.NewPaylinkTokenStatus()
+    s.SetAmountPaid(exampleStatusAmount)
+    s.SetAuthCode(exampleStatusAuthCode)
+    s.SetCard(exampleStatusCard)
+    s.SetCreated(exampleStatusCreated)
+    s.SetDatetime(exampleStatusDatetime)
+    s.SetIdentifier(exampleStatusIdentifier)
+    s.SetIsPaid(exampleStatusIsPaid)
+    s.SetMid(exampleStatusMid)
+    s.SetStateHistory(buildExamplePaylinkStateEventSlice())
+    s.SetToken(exampleStatusToken)
+    s.SetTransNo(exampleStatusTransNo)
+    return *s
+}
+
+func TestNewPaylinkTokenStatus(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatus()
+    require.NotNil(t, model)
+    assert.False(t, model.HasToken())
+}
+
+func TestNewPaylinkTokenStatusWithDefaults(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatusWithDefaults()
+    require.NotNil(t, model)
+    assert.False(t, model.HasIsPaid())
+}
+
+func TestPaylinkTokenStatusSetGetCycle(t *testing.T) {
+    model := openapiclient.NewPaylinkTokenStatus()
+    model.SetAmountPaid(exampleStatusAmount)
+    assert.True(t, model.HasAmountPaid())
+    assert.Equal(t, exampleStatusAmount, model.GetAmountPaid())
+
+    model.SetAuthCode(exampleStatusAuthCode)
+    assert.True(t, model.HasAuthCode())
+    assert.Equal(t, exampleStatusAuthCode, model.GetAuthCode())
+
+    model.SetCard(exampleStatusCard)
+    assert.True(t, model.HasCard())
+    assert.Equal(t, exampleStatusCard, model.GetCard())
+
+    model.SetCreated(exampleStatusCreated)
+    assert.True(t, model.HasCreated())
+    assert.Equal(t, exampleStatusCreated, model.GetCreated())
+
+    model.SetDatetime(exampleStatusDatetime)
+    assert.True(t, model.HasDatetime())
+    assert.Equal(t, exampleStatusDatetime, model.GetDatetime())
+
+    model.SetIdentifier(exampleStatusIdentifier)
+    assert.True(t, model.HasIdentifier())
+    assert.Equal(t, exampleStatusIdentifier, model.GetIdentifier())
+
+    model.SetIsPaid(exampleStatusIsPaid)
+    assert.True(t, model.HasIsPaid())
+    assert.Equal(t, exampleStatusIsPaid, model.GetIsPaid())
+
+    model.SetMid(exampleStatusMid)
+    assert.True(t, model.HasMid())
+    assert.Equal(t, exampleStatusMid, model.GetMid())
+
+    history := buildExamplePaylinkStateEventSlice()
+    model.SetStateHistory(history)
+    assert.True(t, model.HasStateHistory())
+    assert.Len(t, model.GetStateHistory(), 1)
+
+    model.SetToken(exampleStatusToken)
+    assert.True(t, model.HasToken())
+    assert.Equal(t, exampleStatusToken, model.GetToken())
+
+    model.SetTransNo(exampleStatusTransNo)
+    assert.True(t, model.HasTransNo())
+    assert.Equal(t, exampleStatusTransNo, model.GetTransNo())
+}
+
+func TestPaylinkTokenStatusJSONRoundTrip(t *testing.T) {
+    model := buildExamplePaylinkTokenStatus()
+    data, err := json.Marshal(model)
+    require.NoError(t, err)
+
+    var unmarshalled openapiclient.PaylinkTokenStatus
+    err = json.Unmarshal(data, &unmarshalled)
+    require.NoError(t, err)
+    assert.True(t, unmarshalled.HasMid())
+    assert.Equal(t, exampleStatusMid, unmarshalled.GetMid())
+}
+
+func TestPaylinkTokenStatusToMap(t *testing.T) {
+    model := buildExamplePaylinkTokenStatus()
+    m, err := model.ToMap()
+    require.NoError(t, err)
+    if assert.Contains(t, m, "token") {
+        assert.Equal(t, &exampleStatusToken, m["token"])
+    }
+}
+
+func TestNullablePaylinkTokenStatusGetSet(t *testing.T) {
+    base := buildExamplePaylinkTokenStatus()
+    n := openapiclient.NullablePaylinkTokenStatus{}
+    n.Set(&base)
+    require.True(t, n.IsSet())
+    assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusUnset(t *testing.T) {
+    base := buildExamplePaylinkTokenStatus()
+    n := openapiclient.NewNullablePaylinkTokenStatus(&base)
+    require.True(t, n.IsSet())
+    n.Unset()
+    assert.False(t, n.IsSet())
+    assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkTokenStatusJSONRoundTrip(t *testing.T) {
+    base := buildExamplePaylinkTokenStatus()
+    n := openapiclient.NewNullablePaylinkTokenStatus(&base)
+    data, err := json.Marshal(n)
+    require.NoError(t, err)
+
+    var newN openapiclient.NullablePaylinkTokenStatus
+    err = json.Unmarshal(data, &newN)
+    require.NoError(t, err)
+    assert.True(t, newN.IsSet())
+    if assert.NotNil(t, newN.Get()) {
+        assert.Equal(t, exampleStatusTransNo, newN.Get().GetTransNo())
+    }
+}
+

--- a/test/model/model_paylink_ui_test.go
+++ b/test/model/model_paylink_ui_test.go
@@ -1,0 +1,107 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleUIAddressMandatory = true
+var exampleUIAutocomplete = "off"
+var exampleUIOrdering int32 = 3
+var exampleUIPostcode = true
+
+func buildExamplePaylinkUI() openapiclient.PaylinkUI {
+	u := openapiclient.NewPaylinkUI()
+	u.SetAddressMandatory(exampleUIAddressMandatory)
+	u.SetFormAutoComplete(exampleUIAutocomplete)
+	u.SetOrdering(exampleUIOrdering)
+	u.SetPostcodeMandatory(exampleUIPostcode)
+	return *u
+}
+
+func TestNewPaylinkUI(t *testing.T) {
+	model := openapiclient.NewPaylinkUI()
+	require.NotNil(t, model)
+	assert.False(t, model.HasOrdering())
+}
+
+func TestNewPaylinkUIWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaylinkUIWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasPostcodeMandatory())
+}
+
+func TestPaylinkUISetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaylinkUI()
+	model.SetAddressMandatory(exampleUIAddressMandatory)
+	assert.True(t, model.HasAddressMandatory())
+	assert.Equal(t, exampleUIAddressMandatory, model.GetAddressMandatory())
+
+	model.SetFormAutoComplete(exampleUIAutocomplete)
+	assert.True(t, model.HasFormAutoComplete())
+	assert.Equal(t, exampleUIAutocomplete, model.GetFormAutoComplete())
+
+	model.SetOrdering(exampleUIOrdering)
+	assert.True(t, model.HasOrdering())
+	assert.Equal(t, exampleUIOrdering, model.GetOrdering())
+
+	model.SetPostcodeMandatory(exampleUIPostcode)
+	assert.True(t, model.HasPostcodeMandatory())
+	assert.Equal(t, exampleUIPostcode, model.GetPostcodeMandatory())
+}
+
+func TestPaylinkUIJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaylinkUI()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaylinkUI
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasOrdering())
+	assert.Equal(t, exampleUIOrdering, unmarshalled.GetOrdering())
+}
+
+func TestPaylinkUIToMap(t *testing.T) {
+	model := buildExamplePaylinkUI()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "address_mandatory") {
+		assert.Equal(t, &exampleUIAddressMandatory, m["address_mandatory"])
+	}
+}
+
+func TestNullablePaylinkUIGetSet(t *testing.T) {
+	base := buildExamplePaylinkUI()
+	n := openapiclient.NullablePaylinkUI{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaylinkUIUnset(t *testing.T) {
+	base := buildExamplePaylinkUI()
+	n := openapiclient.NewNullablePaylinkUI(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaylinkUIJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaylinkUI()
+	n := openapiclient.NewNullablePaylinkUI(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaylinkUI
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleUIAutocomplete, newN.Get().GetFormAutoComplete())
+	}
+}

--- a/test/model/model_payment_intent_reference_test.go
+++ b/test/model/model_payment_intent_reference_test.go
@@ -1,0 +1,84 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleIntentRefId = "intent123"
+
+func buildExamplePaymentIntentReference() openapiclient.PaymentIntentReference {
+	r := openapiclient.NewPaymentIntentReference(exampleIntentRefId)
+	return *r
+}
+
+func TestNewPaymentIntentReference(t *testing.T) {
+	model := openapiclient.NewPaymentIntentReference(exampleIntentRefId)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleIntentRefId, model.GetPaymentIntentId())
+}
+
+func TestNewPaymentIntentReferenceWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaymentIntentReferenceWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, "", model.GetPaymentIntentId())
+}
+
+func TestPaymentIntentReferenceSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaymentIntentReference(exampleIntentRefId)
+	model.SetPaymentIntentId(exampleIntentRefId + "2")
+	assert.Equal(t, exampleIntentRefId+"2", model.GetPaymentIntentId())
+}
+
+func TestPaymentIntentReferenceJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaymentIntentReference()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaymentIntentReference
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleIntentRefId, unmarshalled.GetPaymentIntentId())
+}
+
+func TestPaymentIntentReferenceToMap(t *testing.T) {
+	model := buildExamplePaymentIntentReference()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleIntentRefId, m["payment_intent_id"])
+}
+
+func TestNullablePaymentIntentReferenceGetSet(t *testing.T) {
+	base := buildExamplePaymentIntentReference()
+	n := openapiclient.NullablePaymentIntentReference{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaymentIntentReferenceUnset(t *testing.T) {
+	base := buildExamplePaymentIntentReference()
+	n := openapiclient.NewNullablePaymentIntentReference(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaymentIntentReferenceJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaymentIntentReference()
+	n := openapiclient.NewNullablePaymentIntentReference(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaymentIntentReference
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleIntentRefId, newN.Get().GetPaymentIntentId())
+	}
+}

--- a/test/model/model_payment_intent_test.go
+++ b/test/model/model_payment_intent_test.go
@@ -1,0 +1,162 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleIntentAmount int32 = 500
+var exampleIntentIdentifier = "pid"
+var exampleIntentAvsPolicy = "1"
+var exampleIntentCsc = "123"
+var exampleIntentCscPolicy = "2"
+var exampleIntentCurrency = "GBP"
+var exampleIntentDupPolicy = "1"
+var exampleIntentMatchAvsa = "Y"
+var exampleIntentTransInfo = "info"
+var exampleIntentTransType = "SALE"
+var exampleIntentTag = []string{"t1", "t2"}
+
+func buildExampleContact() openapiclient.ContactDetails {
+	c := openapiclient.NewContactDetails()
+	c.SetAddress1("street")
+	c.SetEmail("x@example.com")
+	return *c
+}
+
+func buildExamplePaymentIntent() openapiclient.PaymentIntent {
+	p := openapiclient.NewPaymentIntent(exampleIntentAmount, exampleIntentIdentifier)
+	p.SetAvsPostcodePolicy(exampleIntentAvsPolicy)
+	p.SetBillTo(buildExampleContact())
+	p.SetCsc(exampleIntentCsc)
+	p.SetCscPolicy(exampleIntentCscPolicy)
+	p.SetCurrency(exampleIntentCurrency)
+	p.SetDuplicatePolicy(exampleIntentDupPolicy)
+	p.SetMatchAvsa(exampleIntentMatchAvsa)
+	p.SetShipTo(buildExampleContact())
+	p.SetTag(exampleIntentTag)
+	p.SetTransInfo(exampleIntentTransInfo)
+	p.SetTransType(exampleIntentTransType)
+	return *p
+}
+
+func TestNewPaymentIntent(t *testing.T) {
+	model := openapiclient.NewPaymentIntent(exampleIntentAmount, exampleIntentIdentifier)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleIntentAmount, model.GetAmount())
+	assert.Equal(t, exampleIntentIdentifier, model.GetIdentifier())
+	assert.False(t, model.HasCurrency())
+}
+
+func TestNewPaymentIntentWithDefaults(t *testing.T) {
+	model := openapiclient.NewPaymentIntentWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+	assert.False(t, model.HasTag())
+}
+
+func TestPaymentIntentSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPaymentIntent(exampleIntentAmount, exampleIntentIdentifier)
+	model.SetAvsPostcodePolicy(exampleIntentAvsPolicy)
+	assert.True(t, model.HasAvsPostcodePolicy())
+	assert.Equal(t, exampleIntentAvsPolicy, model.GetAvsPostcodePolicy())
+
+	ct := buildExampleContact()
+	model.SetBillTo(ct)
+	assert.True(t, model.HasBillTo())
+	assert.Equal(t, ct, model.GetBillTo())
+
+	model.SetCsc(exampleIntentCsc)
+	assert.True(t, model.HasCsc())
+	assert.Equal(t, exampleIntentCsc, model.GetCsc())
+
+	model.SetCscPolicy(exampleIntentCscPolicy)
+	assert.True(t, model.HasCscPolicy())
+	assert.Equal(t, exampleIntentCscPolicy, model.GetCscPolicy())
+
+	model.SetCurrency(exampleIntentCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleIntentCurrency, model.GetCurrency())
+
+	model.SetDuplicatePolicy(exampleIntentDupPolicy)
+	assert.True(t, model.HasDuplicatePolicy())
+	assert.Equal(t, exampleIntentDupPolicy, model.GetDuplicatePolicy())
+
+	model.SetMatchAvsa(exampleIntentMatchAvsa)
+	assert.True(t, model.HasMatchAvsa())
+	assert.Equal(t, exampleIntentMatchAvsa, model.GetMatchAvsa())
+
+	ship := buildExampleContact()
+	model.SetShipTo(ship)
+	assert.True(t, model.HasShipTo())
+	assert.Equal(t, ship, model.GetShipTo())
+
+	model.SetTag(exampleIntentTag)
+	assert.True(t, model.HasTag())
+	assert.Equal(t, exampleIntentTag, model.GetTag())
+
+	model.SetTransInfo(exampleIntentTransInfo)
+	assert.True(t, model.HasTransInfo())
+	assert.Equal(t, exampleIntentTransInfo, model.GetTransInfo())
+
+	model.SetTransType(exampleIntentTransType)
+	assert.True(t, model.HasTransType())
+	assert.Equal(t, exampleIntentTransType, model.GetTransType())
+}
+
+func TestPaymentIntentJSONRoundTrip(t *testing.T) {
+	model := buildExamplePaymentIntent()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.PaymentIntent
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasBillTo())
+	assert.Equal(t, exampleIntentCurrency, unmarshalled.GetCurrency())
+}
+
+func TestPaymentIntentToMap(t *testing.T) {
+	model := buildExamplePaymentIntent()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleIntentAmount, m["amount"])
+	if assert.Contains(t, m, "tag") {
+		assert.Equal(t, exampleIntentTag, m["tag"])
+	}
+}
+
+func TestNullablePaymentIntentGetSet(t *testing.T) {
+	base := buildExamplePaymentIntent()
+	n := openapiclient.NullablePaymentIntent{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePaymentIntentUnset(t *testing.T) {
+	base := buildExamplePaymentIntent()
+	n := openapiclient.NewNullablePaymentIntent(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePaymentIntentJSONRoundTrip(t *testing.T) {
+	base := buildExamplePaymentIntent()
+	n := openapiclient.NewNullablePaymentIntent(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePaymentIntent
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleIntentDupPolicy, newN.Get().GetDuplicatePolicy())
+	}
+}

--- a/test/model/model_ping_test.go
+++ b/test/model/model_ping_test.go
@@ -1,0 +1,89 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var examplePingID = "ping1"
+
+func buildExamplePing() openapiclient.Ping {
+	p := openapiclient.NewPing()
+	p.SetIdentifier(examplePingID)
+	return *p
+}
+
+func TestNewPing(t *testing.T) {
+	model := openapiclient.NewPing()
+	require.NotNil(t, model)
+	assert.False(t, model.HasIdentifier())
+}
+
+func TestNewPingWithDefaults(t *testing.T) {
+	model := openapiclient.NewPingWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasIdentifier())
+}
+
+func TestPingSetGetCycle(t *testing.T) {
+	model := openapiclient.NewPing()
+	model.SetIdentifier(examplePingID)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, examplePingID, model.GetIdentifier())
+}
+
+func TestPingJSONRoundTrip(t *testing.T) {
+	model := buildExamplePing()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.Ping
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasIdentifier())
+	assert.Equal(t, examplePingID, unmarshalled.GetIdentifier())
+}
+
+func TestPingToMap(t *testing.T) {
+	model := buildExamplePing()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "identifier") {
+		assert.Equal(t, &examplePingID, m["identifier"])
+	}
+}
+
+func TestNullablePingGetSet(t *testing.T) {
+	base := buildExamplePing()
+	n := openapiclient.NullablePing{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullablePingUnset(t *testing.T) {
+	base := buildExamplePing()
+	n := openapiclient.NewNullablePing(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullablePingJSONRoundTrip(t *testing.T) {
+	base := buildExamplePing()
+	n := openapiclient.NewNullablePing(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullablePing
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, examplePingID, newN.Get().GetIdentifier())
+	}
+}

--- a/test/model/model_process_batch_request_test.go
+++ b/test/model/model_process_batch_request_test.go
@@ -1,0 +1,105 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleProcessDate = "2024-01-01"
+var exampleProcessID int32 = 7
+var exampleProcessClient = "cli"
+
+func buildExampleBatchTransaction() openapiclient.BatchTransaction {
+	b := openapiclient.NewBatchTransaction("acc", 10)
+	b.SetIdentifier("id")
+	b.SetMerchantid(1)
+	return *b
+}
+
+func buildExampleProcessBatchRequest() openapiclient.ProcessBatchRequest {
+	p := openapiclient.NewProcessBatchRequest(exampleProcessDate, exampleProcessID, []openapiclient.BatchTransaction{buildExampleBatchTransaction()})
+	p.SetClientAccountId(exampleProcessClient)
+	return *p
+}
+
+func TestNewProcessBatchRequest(t *testing.T) {
+	model := openapiclient.NewProcessBatchRequest(exampleProcessDate, exampleProcessID, []openapiclient.BatchTransaction{})
+	require.NotNil(t, model)
+	assert.Equal(t, exampleProcessDate, model.GetBatchDate())
+	assert.Equal(t, exampleProcessID, model.GetBatchId())
+	assert.False(t, model.HasClientAccountId())
+}
+
+func TestNewProcessBatchRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewProcessBatchRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasTransactions())
+}
+
+func TestProcessBatchRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewProcessBatchRequest(exampleProcessDate, exampleProcessID, []openapiclient.BatchTransaction{})
+	model.SetClientAccountId(exampleProcessClient)
+	assert.True(t, model.HasClientAccountId())
+	assert.Equal(t, exampleProcessClient, model.GetClientAccountId())
+
+	tx := buildExampleBatchTransaction()
+	model.SetTransactions([]openapiclient.BatchTransaction{tx})
+	assert.Len(t, model.GetTransactions(), 1)
+}
+
+func TestProcessBatchRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleProcessBatchRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ProcessBatchRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasClientAccountId())
+	assert.Equal(t, exampleProcessClient, unmarshalled.GetClientAccountId())
+}
+
+func TestProcessBatchRequestToMap(t *testing.T) {
+	model := buildExampleProcessBatchRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleProcessDate, m["batch_date"])
+	if assert.Contains(t, m, "client_account_id") {
+		assert.Equal(t, &exampleProcessClient, m["client_account_id"])
+	}
+}
+
+func TestNullableProcessBatchRequestGetSet(t *testing.T) {
+	base := buildExampleProcessBatchRequest()
+	n := openapiclient.NullableProcessBatchRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableProcessBatchRequestUnset(t *testing.T) {
+	base := buildExampleProcessBatchRequest()
+	n := openapiclient.NewNullableProcessBatchRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableProcessBatchRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleProcessBatchRequest()
+	n := openapiclient.NewNullableProcessBatchRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableProcessBatchRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleProcessID, newN.Get().GetBatchId())
+	}
+}

--- a/test/model/model_process_batch_response_test.go
+++ b/test/model/model_process_batch_response_test.go
@@ -1,0 +1,92 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleProcessMessage = "ok"
+var exampleProcessValid = true
+
+func buildExampleProcessBatchResponse() openapiclient.ProcessBatchResponse {
+	r := openapiclient.NewProcessBatchResponse(exampleProcessValid)
+	r.SetMessage(exampleProcessMessage)
+	return *r
+}
+
+func TestNewProcessBatchResponse(t *testing.T) {
+	model := openapiclient.NewProcessBatchResponse(exampleProcessValid)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleProcessValid, model.GetValid())
+	assert.False(t, model.HasMessage())
+}
+
+func TestNewProcessBatchResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewProcessBatchResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.GetValid())
+}
+
+func TestProcessBatchResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewProcessBatchResponse(exampleProcessValid)
+	model.SetMessage(exampleProcessMessage)
+	assert.True(t, model.HasMessage())
+	assert.Equal(t, exampleProcessMessage, model.GetMessage())
+}
+
+func TestProcessBatchResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleProcessBatchResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ProcessBatchResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMessage())
+	assert.Equal(t, exampleProcessMessage, unmarshalled.GetMessage())
+}
+
+func TestProcessBatchResponseToMap(t *testing.T) {
+	model := buildExampleProcessBatchResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleProcessValid, m["valid"])
+	if assert.Contains(t, m, "message") {
+		assert.Equal(t, &exampleProcessMessage, m["message"])
+	}
+}
+
+func TestNullableProcessBatchResponseGetSet(t *testing.T) {
+	base := buildExampleProcessBatchResponse()
+	n := openapiclient.NullableProcessBatchResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableProcessBatchResponseUnset(t *testing.T) {
+	base := buildExampleProcessBatchResponse()
+	n := openapiclient.NewNullableProcessBatchResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableProcessBatchResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleProcessBatchResponse()
+	n := openapiclient.NewNullableProcessBatchResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableProcessBatchResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleProcessValid, newN.Get().GetValid())
+	}
+}

--- a/test/model/model_refund_request_test.go
+++ b/test/model/model_refund_request_test.go
@@ -1,0 +1,98 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleRefundAmount int32 = 999
+var exampleRefundIdentifier = "ref1"
+var exampleRefundMid int32 = 5
+var exampleRefundRef int32 = 10
+var exampleRefundInfo = "details"
+
+func buildExampleRefundRequest() openapiclient.RefundRequest {
+	r := openapiclient.NewRefundRequest(exampleRefundAmount, exampleRefundIdentifier, exampleRefundMid, exampleRefundRef)
+	r.SetTransInfo(exampleRefundInfo)
+	return *r
+}
+
+func TestNewRefundRequest(t *testing.T) {
+	model := openapiclient.NewRefundRequest(exampleRefundAmount, exampleRefundIdentifier, exampleRefundMid, exampleRefundRef)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleRefundAmount, model.GetAmount())
+	assert.Equal(t, exampleRefundIdentifier, model.GetIdentifier())
+	assert.Equal(t, exampleRefundMid, model.GetMerchantid())
+	assert.Equal(t, exampleRefundRef, model.GetRefundRef())
+	assert.False(t, model.HasTransInfo())
+}
+
+func TestNewRefundRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewRefundRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+}
+
+func TestRefundRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRefundRequest(exampleRefundAmount, exampleRefundIdentifier, exampleRefundMid, exampleRefundRef)
+	model.SetTransInfo(exampleRefundInfo)
+	assert.True(t, model.HasTransInfo())
+	assert.Equal(t, exampleRefundInfo, model.GetTransInfo())
+}
+
+func TestRefundRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleRefundRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RefundRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasTransInfo())
+	assert.Equal(t, exampleRefundInfo, unmarshalled.GetTransInfo())
+}
+
+func TestRefundRequestToMap(t *testing.T) {
+	model := buildExampleRefundRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleRefundAmount, m["amount"])
+	if assert.Contains(t, m, "trans_info") {
+		assert.Equal(t, &exampleRefundInfo, m["trans_info"])
+	}
+}
+
+func TestNullableRefundRequestGetSet(t *testing.T) {
+	base := buildExampleRefundRequest()
+	n := openapiclient.NullableRefundRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRefundRequestUnset(t *testing.T) {
+	base := buildExampleRefundRequest()
+	n := openapiclient.NewNullableRefundRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRefundRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleRefundRequest()
+	n := openapiclient.NewNullableRefundRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRefundRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRefundMid, newN.Get().GetMerchantid())
+	}
+}

--- a/test/model/model_register_card_test.go
+++ b/test/model/model_register_card_test.go
@@ -1,0 +1,102 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleRegCardNumber = "4111111111111111"
+var exampleRegDefault = true
+var exampleRegMonth int32 = 1
+var exampleRegYear int32 = 25
+var exampleRegName = "Jane Doe"
+
+func buildExampleRegisterCard() openapiclient.RegisterCard {
+	r := openapiclient.NewRegisterCard(exampleRegCardNumber, exampleRegMonth, exampleRegYear)
+	r.SetDefault(exampleRegDefault)
+	r.SetNameOnCard(exampleRegName)
+	return *r
+}
+
+func TestNewRegisterCard(t *testing.T) {
+	model := openapiclient.NewRegisterCard(exampleRegCardNumber, exampleRegMonth, exampleRegYear)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleRegCardNumber, model.GetCardnumber())
+	assert.Equal(t, exampleRegMonth, model.GetExpmonth())
+	assert.Equal(t, exampleRegYear, model.GetExpyear())
+	assert.False(t, model.HasDefault())
+}
+
+func TestNewRegisterCardWithDefaults(t *testing.T) {
+	model := openapiclient.NewRegisterCardWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasNameOnCard())
+}
+
+func TestRegisterCardSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRegisterCard(exampleRegCardNumber, exampleRegMonth, exampleRegYear)
+	model.SetDefault(exampleRegDefault)
+	assert.True(t, model.HasDefault())
+	assert.Equal(t, exampleRegDefault, model.GetDefault())
+
+	model.SetNameOnCard(exampleRegName)
+	assert.True(t, model.HasNameOnCard())
+	assert.Equal(t, exampleRegName, model.GetNameOnCard())
+}
+
+func TestRegisterCardJSONRoundTrip(t *testing.T) {
+	model := buildExampleRegisterCard()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RegisterCard
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasDefault())
+	assert.Equal(t, exampleRegName, unmarshalled.GetNameOnCard())
+}
+
+func TestRegisterCardToMap(t *testing.T) {
+	model := buildExampleRegisterCard()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleRegCardNumber, m["cardnumber"])
+	if assert.Contains(t, m, "name_on_card") {
+		assert.Equal(t, &exampleRegName, m["name_on_card"])
+	}
+}
+
+func TestNullableRegisterCardGetSet(t *testing.T) {
+	base := buildExampleRegisterCard()
+	n := openapiclient.NullableRegisterCard{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRegisterCardUnset(t *testing.T) {
+	base := buildExampleRegisterCard()
+	n := openapiclient.NewNullableRegisterCard(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRegisterCardJSONRoundTrip(t *testing.T) {
+	base := buildExampleRegisterCard()
+	n := openapiclient.NewNullableRegisterCard(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRegisterCard
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRegMonth, newN.Get().GetExpmonth())
+	}
+}

--- a/test/model/model_remittance_data_test.go
+++ b/test/model/model_remittance_data_test.go
@@ -1,0 +1,120 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleRemitDate = time.Date(2024, time.January, 2, 0, 0, 0, 0, time.UTC)
+var exampleRemitNet int32 = 50
+var exampleRemitRefund int32 = 5
+var exampleRemitRefundCount int32 = 1
+var exampleRemitSales int32 = 55
+var exampleRemitSalesCount int32 = 2
+
+func buildExampleRemittanceData() openapiclient.RemittanceData {
+	r := openapiclient.NewRemittanceData()
+	r.SetDateCreated(exampleRemitDate)
+	r.SetNetAmount(exampleRemitNet)
+	r.SetRefundAmount(exampleRemitRefund)
+	r.SetRefundCount(exampleRemitRefundCount)
+	r.SetSalesAmount(exampleRemitSales)
+	r.SetSalesCount(exampleRemitSalesCount)
+	return *r
+}
+
+func TestNewRemittanceData(t *testing.T) {
+	model := openapiclient.NewRemittanceData()
+	require.NotNil(t, model)
+	assert.False(t, model.HasNetAmount())
+}
+
+func TestNewRemittanceDataWithDefaults(t *testing.T) {
+	model := openapiclient.NewRemittanceDataWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasRefundCount())
+}
+
+func TestRemittanceDataSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRemittanceData()
+	model.SetDateCreated(exampleRemitDate)
+	assert.True(t, model.HasDateCreated())
+	assert.Equal(t, exampleRemitDate, model.GetDateCreated())
+
+	model.SetNetAmount(exampleRemitNet)
+	assert.True(t, model.HasNetAmount())
+	assert.Equal(t, exampleRemitNet, model.GetNetAmount())
+
+	model.SetRefundAmount(exampleRemitRefund)
+	assert.True(t, model.HasRefundAmount())
+	assert.Equal(t, exampleRemitRefund, model.GetRefundAmount())
+
+	model.SetRefundCount(exampleRemitRefundCount)
+	assert.True(t, model.HasRefundCount())
+	assert.Equal(t, exampleRemitRefundCount, model.GetRefundCount())
+
+	model.SetSalesAmount(exampleRemitSales)
+	assert.True(t, model.HasSalesAmount())
+	assert.Equal(t, exampleRemitSales, model.GetSalesAmount())
+
+	model.SetSalesCount(exampleRemitSalesCount)
+	assert.True(t, model.HasSalesCount())
+	assert.Equal(t, exampleRemitSalesCount, model.GetSalesCount())
+}
+
+func TestRemittanceDataJSONRoundTrip(t *testing.T) {
+	model := buildExampleRemittanceData()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RemittanceData
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasRefundCount())
+	assert.Equal(t, exampleRemitRefundCount, unmarshalled.GetRefundCount())
+}
+
+func TestRemittanceDataToMap(t *testing.T) {
+	model := buildExampleRemittanceData()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "net_amount") {
+		assert.Equal(t, &exampleRemitNet, m["net_amount"])
+	}
+}
+
+func TestNullableRemittanceDataGetSet(t *testing.T) {
+	base := buildExampleRemittanceData()
+	n := openapiclient.NullableRemittanceData{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRemittanceDataUnset(t *testing.T) {
+	base := buildExampleRemittanceData()
+	n := openapiclient.NewNullableRemittanceData(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRemittanceDataJSONRoundTrip(t *testing.T) {
+	base := buildExampleRemittanceData()
+	n := openapiclient.NewNullableRemittanceData(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRemittanceData
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRemitSales, newN.Get().GetSalesAmount())
+	}
+}

--- a/test/model/model_remittance_report_request_test.go
+++ b/test/model/model_remittance_report_request_test.go
@@ -1,0 +1,119 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleRepFrom = "2024-01-01"
+var exampleRepUntil = "2024-01-31"
+var exampleRepMax int32 = 20
+var exampleRepMerchant = []int32{1, 2}
+var exampleRepNext = "tok"
+var exampleRepOrder = "-date"
+
+func buildExampleRemittanceReportRequest() openapiclient.RemittanceReportRequest {
+	r := openapiclient.NewRemittanceReportRequest()
+	r.SetDateFrom(exampleRepFrom)
+	r.SetDateUntil(exampleRepUntil)
+	r.SetMaxResults(exampleRepMax)
+	r.SetMerchantId(exampleRepMerchant)
+	r.SetNextToken(exampleRepNext)
+	r.SetOrderBy(exampleRepOrder)
+	return *r
+}
+
+func TestNewRemittanceReportRequest(t *testing.T) {
+	model := openapiclient.NewRemittanceReportRequest()
+	require.NotNil(t, model)
+	assert.False(t, model.HasDateFrom())
+}
+
+func TestNewRemittanceReportRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewRemittanceReportRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasMerchantId())
+}
+
+func TestRemittanceReportRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRemittanceReportRequest()
+	model.SetDateFrom(exampleRepFrom)
+	assert.True(t, model.HasDateFrom())
+	assert.Equal(t, exampleRepFrom, model.GetDateFrom())
+
+	model.SetDateUntil(exampleRepUntil)
+	assert.True(t, model.HasDateUntil())
+	assert.Equal(t, exampleRepUntil, model.GetDateUntil())
+
+	model.SetMaxResults(exampleRepMax)
+	assert.True(t, model.HasMaxResults())
+	assert.Equal(t, exampleRepMax, model.GetMaxResults())
+
+	model.SetMerchantId(exampleRepMerchant)
+	assert.True(t, model.HasMerchantId())
+	assert.Equal(t, exampleRepMerchant, model.GetMerchantId())
+
+	model.SetNextToken(exampleRepNext)
+	assert.True(t, model.HasNextToken())
+	assert.Equal(t, exampleRepNext, model.GetNextToken())
+
+	model.SetOrderBy(exampleRepOrder)
+	assert.True(t, model.HasOrderBy())
+	assert.Equal(t, exampleRepOrder, model.GetOrderBy())
+}
+
+func TestRemittanceReportRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleRemittanceReportRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RemittanceReportRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMerchantId())
+	assert.Equal(t, exampleRepMerchant, unmarshalled.GetMerchantId())
+}
+
+func TestRemittanceReportRequestToMap(t *testing.T) {
+	model := buildExampleRemittanceReportRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "maxResults") {
+		assert.Equal(t, &exampleRepMax, m["maxResults"])
+	}
+}
+
+func TestNullableRemittanceReportRequestGetSet(t *testing.T) {
+	base := buildExampleRemittanceReportRequest()
+	n := openapiclient.NullableRemittanceReportRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRemittanceReportRequestUnset(t *testing.T) {
+	base := buildExampleRemittanceReportRequest()
+	n := openapiclient.NewNullableRemittanceReportRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRemittanceReportRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleRemittanceReportRequest()
+	n := openapiclient.NewNullableRemittanceReportRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRemittanceReportRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRepOrder, newN.Get().GetOrderBy())
+	}
+}

--- a/test/model/model_remittance_report_response_test.go
+++ b/test/model/model_remittance_report_response_test.go
@@ -1,0 +1,124 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleRemitRespCount int32 = 2
+var exampleRemitRespMax int32 = 10
+var exampleRemitRespNext = "next"
+
+func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+	m := openapiclient.NewMerchantBatchResponse()
+	m.SetBatchId(1)
+	return *m
+}
+
+func buildExampleRemittanceDataSlice() []openapiclient.RemittanceData {
+	r := openapiclient.NewRemittanceData()
+	r.SetDateCreated(time.Now())
+	return []openapiclient.RemittanceData{*r}
+}
+
+func buildExampleRemittedClientData() openapiclient.RemittedClientData {
+	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()}, buildExampleRemittanceDataSlice())
+	d.SetClientid("c1")
+	return *d
+}
+
+func buildExampleRemittanceReportResponse() openapiclient.RemittanceReportResponse {
+	r := openapiclient.NewRemittanceReportResponse([]openapiclient.RemittedClientData{buildExampleRemittedClientData()})
+	r.SetCount(exampleRemitRespCount)
+	r.SetMaxResults(exampleRemitRespMax)
+	r.SetNextToken(exampleRemitRespNext)
+	return *r
+}
+
+func TestNewRemittanceReportResponse(t *testing.T) {
+	model := openapiclient.NewRemittanceReportResponse([]openapiclient.RemittedClientData{})
+	require.NotNil(t, model)
+	assert.NotNil(t, model.GetData())
+	assert.False(t, model.HasCount())
+}
+
+func TestNewRemittanceReportResponseWithDefaults(t *testing.T) {
+	model := openapiclient.NewRemittanceReportResponseWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasMaxResults())
+}
+
+func TestRemittanceReportResponseSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRemittanceReportResponse([]openapiclient.RemittedClientData{})
+	model.SetCount(exampleRemitRespCount)
+	assert.True(t, model.HasCount())
+	assert.Equal(t, exampleRemitRespCount, model.GetCount())
+
+	model.SetData([]openapiclient.RemittedClientData{buildExampleRemittedClientData()})
+	assert.Len(t, model.GetData(), 1)
+
+	model.SetMaxResults(exampleRemitRespMax)
+	assert.True(t, model.HasMaxResults())
+	assert.Equal(t, exampleRemitRespMax, model.GetMaxResults())
+
+	model.SetNextToken(exampleRemitRespNext)
+	assert.True(t, model.HasNextToken())
+	assert.Equal(t, exampleRemitRespNext, model.GetNextToken())
+}
+
+func TestRemittanceReportResponseJSONRoundTrip(t *testing.T) {
+	model := buildExampleRemittanceReportResponse()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RemittanceReportResponse
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCount())
+	assert.Equal(t, exampleRemitRespCount, unmarshalled.GetCount())
+}
+
+func TestRemittanceReportResponseToMap(t *testing.T) {
+	model := buildExampleRemittanceReportResponse()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "nextToken") {
+		assert.Equal(t, &exampleRemitRespNext, m["nextToken"])
+	}
+}
+
+func TestNullableRemittanceReportResponseGetSet(t *testing.T) {
+	base := buildExampleRemittanceReportResponse()
+	n := openapiclient.NullableRemittanceReportResponse{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRemittanceReportResponseUnset(t *testing.T) {
+	base := buildExampleRemittanceReportResponse()
+	n := openapiclient.NewNullableRemittanceReportResponse(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRemittanceReportResponseJSONRoundTrip(t *testing.T) {
+	base := buildExampleRemittanceReportResponse()
+	n := openapiclient.NewNullableRemittanceReportResponse(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRemittanceReportResponse
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRemitRespMax, newN.Get().GetMaxResults())
+	}
+}

--- a/test/model/model_remitted_client_data_test.go
+++ b/test/model/model_remitted_client_data_test.go
@@ -1,0 +1,120 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+var exampleRemittedClientID = "cid"
+var exampleRemittedDate = "2024-01-02"
+var exampleRemittedNet int32 = 50
+
+func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+	m := openapiclient.NewMerchantBatchResponse()
+	m.SetBatchId(1)
+	return *m
+}
+
+func buildExampleRemittanceDataSlice() []openapiclient.RemittanceData {
+	r := openapiclient.NewRemittanceData()
+	r.SetDateCreated(time.Now())
+	return []openapiclient.RemittanceData{*r}
+}
+
+func buildExampleRemittedClientData() openapiclient.RemittedClientData {
+	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()}, buildExampleRemittanceDataSlice())
+	d.SetClientid(exampleRemittedClientID)
+	d.SetDate(&exampleRemittedDate)
+	d.SetNetAmount(exampleRemittedNet)
+	return *d
+}
+
+func TestNewRemittedClientData(t *testing.T) {
+	model := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{}, []openapiclient.RemittanceData{})
+	require.NotNil(t, model)
+	assert.False(t, model.HasClientid())
+}
+
+func TestNewRemittedClientDataWithDefaults(t *testing.T) {
+	model := openapiclient.NewRemittedClientDataWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasRemittances())
+}
+
+func TestRemittedClientDataSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{}, []openapiclient.RemittanceData{})
+	model.SetClientid(exampleRemittedClientID)
+	assert.True(t, model.HasClientid())
+	assert.Equal(t, exampleRemittedClientID, model.GetClientid())
+
+	model.SetDate(&exampleRemittedDate)
+	assert.True(t, model.HasDate())
+	assert.Equal(t, exampleRemittedDate, model.GetDate())
+
+	now := time.Now()
+	model.SetDateCreated(now)
+	assert.True(t, model.HasDateCreated())
+	assert.Equal(t, now, model.GetDateCreated())
+
+	model.SetNetAmount(exampleRemittedNet)
+	assert.True(t, model.HasNetAmount())
+	assert.Equal(t, exampleRemittedNet, model.GetNetAmount())
+}
+
+func TestRemittedClientDataJSONRoundTrip(t *testing.T) {
+	model := buildExampleRemittedClientData()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RemittedClientData
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasClientid())
+	assert.Equal(t, exampleRemittedClientID, unmarshalled.GetClientid())
+}
+
+func TestRemittedClientDataToMap(t *testing.T) {
+	model := buildExampleRemittedClientData()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Contains(t, m, "batches")
+	if assert.Contains(t, m, "clientid") {
+		assert.Equal(t, &exampleRemittedClientID, m["clientid"])
+	}
+}
+
+func TestNullableRemittedClientDataGetSet(t *testing.T) {
+	base := buildExampleRemittedClientData()
+	n := openapiclient.NullableRemittedClientData{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRemittedClientDataUnset(t *testing.T) {
+	base := buildExampleRemittedClientData()
+	n := openapiclient.NewNullableRemittedClientData(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRemittedClientDataJSONRoundTrip(t *testing.T) {
+	base := buildExampleRemittedClientData()
+	n := openapiclient.NewNullableRemittedClientData(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRemittedClientData
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRemittedNet, newN.Get().GetNetAmount())
+	}
+}

--- a/test/model/model_request_challenged_test.go
+++ b/test/model/model_request_challenged_test.go
@@ -1,0 +1,111 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleChallengedURL = "https://acs"
+var exampleChallengedCreq = "creq"
+var exampleChallengedMid int32 = 1
+var exampleChallengedTransID = "tid"
+var exampleChallengedTransNo int32 = 5
+
+func buildExampleRequestChallenged() openapiclient.RequestChallenged {
+	r := openapiclient.NewRequestChallenged()
+	r.SetAcsUrl(exampleChallengedURL)
+	r.SetCreq(exampleChallengedCreq)
+	r.SetMerchantid(exampleChallengedMid)
+	r.SetThreedserverTransId(exampleChallengedTransID)
+	r.SetTransno(exampleChallengedTransNo)
+	return *r
+}
+
+func TestNewRequestChallenged(t *testing.T) {
+	model := openapiclient.NewRequestChallenged()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAcsUrl())
+}
+
+func TestNewRequestChallengedWithDefaults(t *testing.T) {
+	model := openapiclient.NewRequestChallengedWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasTransno())
+}
+
+func TestRequestChallengedSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRequestChallenged()
+	model.SetAcsUrl(exampleChallengedURL)
+	assert.True(t, model.HasAcsUrl())
+	assert.Equal(t, exampleChallengedURL, model.GetAcsUrl())
+
+	model.SetCreq(exampleChallengedCreq)
+	assert.True(t, model.HasCreq())
+	assert.Equal(t, exampleChallengedCreq, model.GetCreq())
+
+	model.SetMerchantid(exampleChallengedMid)
+	assert.True(t, model.HasMerchantid())
+	assert.Equal(t, exampleChallengedMid, model.GetMerchantid())
+
+	model.SetThreedserverTransId(exampleChallengedTransID)
+	assert.True(t, model.HasThreedserverTransId())
+	assert.Equal(t, exampleChallengedTransID, model.GetThreedserverTransId())
+
+	model.SetTransno(exampleChallengedTransNo)
+	assert.True(t, model.HasTransno())
+	assert.Equal(t, exampleChallengedTransNo, model.GetTransno())
+}
+
+func TestRequestChallengedJSONRoundTrip(t *testing.T) {
+	model := buildExampleRequestChallenged()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RequestChallenged
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMerchantid())
+	assert.Equal(t, exampleChallengedMid, unmarshalled.GetMerchantid())
+}
+
+func TestRequestChallengedToMap(t *testing.T) {
+	model := buildExampleRequestChallenged()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, &exampleChallengedURL, m["acs_url"])
+}
+
+func TestNullableRequestChallengedGetSet(t *testing.T) {
+	base := buildExampleRequestChallenged()
+	n := openapiclient.NullableRequestChallenged{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRequestChallengedUnset(t *testing.T) {
+	base := buildExampleRequestChallenged()
+	n := openapiclient.NewNullableRequestChallenged(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRequestChallengedJSONRoundTrip(t *testing.T) {
+	base := buildExampleRequestChallenged()
+	n := openapiclient.NewNullableRequestChallenged(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRequestChallenged
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleChallengedTransID, newN.Get().GetThreedserverTransId())
+	}
+}

--- a/test/model/model_retrieve_request_test.go
+++ b/test/model/model_retrieve_request_test.go
@@ -1,0 +1,98 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleRetrieveIdentifier = "rid"
+var exampleRetrieveMid int32 = 2
+var exampleRetrieveTrans int32 = 10
+
+func buildExampleRetrieveRequest() openapiclient.RetrieveRequest {
+	r := openapiclient.NewRetrieveRequest(exampleRetrieveMid)
+	r.SetIdentifier(exampleRetrieveIdentifier)
+	r.SetTransno(exampleRetrieveTrans)
+	return *r
+}
+
+func TestNewRetrieveRequest(t *testing.T) {
+	model := openapiclient.NewRetrieveRequest(exampleRetrieveMid)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleRetrieveMid, model.GetMerchantid())
+	assert.False(t, model.HasIdentifier())
+}
+
+func TestNewRetrieveRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewRetrieveRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasMerchantid())
+}
+
+func TestRetrieveRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewRetrieveRequest(exampleRetrieveMid)
+	model.SetIdentifier(exampleRetrieveIdentifier)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleRetrieveIdentifier, model.GetIdentifier())
+
+	model.SetTransno(exampleRetrieveTrans)
+	assert.True(t, model.HasTransno())
+	assert.Equal(t, exampleRetrieveTrans, model.GetTransno())
+}
+
+func TestRetrieveRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleRetrieveRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.RetrieveRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasTransno())
+	assert.Equal(t, exampleRetrieveTrans, unmarshalled.GetTransno())
+}
+
+func TestRetrieveRequestToMap(t *testing.T) {
+	model := buildExampleRetrieveRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleRetrieveMid, m["merchantid"])
+	if assert.Contains(t, m, "identifier") {
+		assert.Equal(t, &exampleRetrieveIdentifier, m["identifier"])
+	}
+}
+
+func TestNullableRetrieveRequestGetSet(t *testing.T) {
+	base := buildExampleRetrieveRequest()
+	n := openapiclient.NullableRetrieveRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableRetrieveRequestUnset(t *testing.T) {
+	base := buildExampleRetrieveRequest()
+	n := openapiclient.NewNullableRetrieveRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableRetrieveRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleRetrieveRequest()
+	n := openapiclient.NewNullableRetrieveRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableRetrieveRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleRetrieveIdentifier, newN.Get().GetIdentifier())
+	}
+}

--- a/test/model/model_three_d_secure_test.go
+++ b/test/model/model_three_d_secure_test.go
@@ -1,0 +1,161 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleTDSAccept = "text/html"
+var exampleTDSColor = "32"
+var exampleTDSIP = "127.0.0.1"
+var exampleTDSJava = "false"
+var exampleTDSLang = "en"
+var exampleTDSScreenH = "100"
+var exampleTDSScreenW = "200"
+var exampleTDSTZ = "0"
+var exampleTDSBx = "bx"
+var exampleTDSDowngrade = true
+var exampleTDSTerm = "https://term"
+var exampleTDSPolicy = "1"
+var exampleTDSUser = "UA"
+
+func buildExampleThreeDSecure() openapiclient.ThreeDSecure {
+	t := openapiclient.NewThreeDSecure()
+	t.SetAcceptHeaders(exampleTDSAccept)
+	t.SetBrowserColorDepth(exampleTDSColor)
+	t.SetBrowserIP(exampleTDSIP)
+	t.SetBrowserJavaEnabled(exampleTDSJava)
+	t.SetBrowserLanguage(exampleTDSLang)
+	t.SetBrowserScreenHeight(exampleTDSScreenH)
+	t.SetBrowserScreenWidth(exampleTDSScreenW)
+	t.SetBrowserTZ(exampleTDSTZ)
+	t.SetCpBx(exampleTDSBx)
+	t.SetDowngrade1(exampleTDSDowngrade)
+	t.SetMerchantTermurl(exampleTDSTerm)
+	t.SetTdsPolicy(exampleTDSPolicy)
+	t.SetUserAgent(exampleTDSUser)
+	return *t
+}
+
+func TestNewThreeDSecure(t *testing.T) {
+	model := openapiclient.NewThreeDSecure()
+	require.NotNil(t, model)
+	assert.False(t, model.HasUserAgent())
+}
+
+func TestNewThreeDSecureWithDefaults(t *testing.T) {
+	model := openapiclient.NewThreeDSecureWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasDowngrade1())
+}
+
+func TestThreeDSecureSetGetCycle(t *testing.T) {
+	model := openapiclient.NewThreeDSecure()
+	model.SetAcceptHeaders(exampleTDSAccept)
+	assert.True(t, model.HasAcceptHeaders())
+	assert.Equal(t, exampleTDSAccept, model.GetAcceptHeaders())
+
+	model.SetBrowserColorDepth(exampleTDSColor)
+	assert.True(t, model.HasBrowserColorDepth())
+	assert.Equal(t, exampleTDSColor, model.GetBrowserColorDepth())
+
+	model.SetBrowserIP(exampleTDSIP)
+	assert.True(t, model.HasBrowserIP())
+	assert.Equal(t, exampleTDSIP, model.GetBrowserIP())
+
+	model.SetBrowserJavaEnabled(exampleTDSJava)
+	assert.True(t, model.HasBrowserJavaEnabled())
+	assert.Equal(t, exampleTDSJava, model.GetBrowserJavaEnabled())
+
+	model.SetBrowserLanguage(exampleTDSLang)
+	assert.True(t, model.HasBrowserLanguage())
+	assert.Equal(t, exampleTDSLang, model.GetBrowserLanguage())
+
+	model.SetBrowserScreenHeight(exampleTDSScreenH)
+	assert.True(t, model.HasBrowserScreenHeight())
+	assert.Equal(t, exampleTDSScreenH, model.GetBrowserScreenHeight())
+
+	model.SetBrowserScreenWidth(exampleTDSScreenW)
+	assert.True(t, model.HasBrowserScreenWidth())
+	assert.Equal(t, exampleTDSScreenW, model.GetBrowserScreenWidth())
+
+	model.SetBrowserTZ(exampleTDSTZ)
+	assert.True(t, model.HasBrowserTZ())
+	assert.Equal(t, exampleTDSTZ, model.GetBrowserTZ())
+
+	model.SetCpBx(exampleTDSBx)
+	assert.True(t, model.HasCpBx())
+	assert.Equal(t, exampleTDSBx, model.GetCpBx())
+
+	model.SetDowngrade1(exampleTDSDowngrade)
+	assert.True(t, model.HasDowngrade1())
+	assert.Equal(t, exampleTDSDowngrade, model.GetDowngrade1())
+
+	model.SetMerchantTermurl(exampleTDSTerm)
+	assert.True(t, model.HasMerchantTermurl())
+	assert.Equal(t, exampleTDSTerm, model.GetMerchantTermurl())
+
+	model.SetTdsPolicy(exampleTDSPolicy)
+	assert.True(t, model.HasTdsPolicy())
+	assert.Equal(t, exampleTDSPolicy, model.GetTdsPolicy())
+
+	model.SetUserAgent(exampleTDSUser)
+	assert.True(t, model.HasUserAgent())
+	assert.Equal(t, exampleTDSUser, model.GetUserAgent())
+}
+
+func TestThreeDSecureJSONRoundTrip(t *testing.T) {
+	model := buildExampleThreeDSecure()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.ThreeDSecure
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasCpBx())
+	assert.Equal(t, exampleTDSBx, unmarshalled.GetCpBx())
+}
+
+func TestThreeDSecureToMap(t *testing.T) {
+	model := buildExampleThreeDSecure()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "browserIP") {
+		assert.Equal(t, &exampleTDSIP, m["browserIP"])
+	}
+}
+
+func TestNullableThreeDSecureGetSet(t *testing.T) {
+	base := buildExampleThreeDSecure()
+	n := openapiclient.NullableThreeDSecure{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableThreeDSecureUnset(t *testing.T) {
+	base := buildExampleThreeDSecure()
+	n := openapiclient.NewNullableThreeDSecure(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableThreeDSecureJSONRoundTrip(t *testing.T) {
+	base := buildExampleThreeDSecure()
+	n := openapiclient.NewNullableThreeDSecure(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableThreeDSecure
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleTDSPolicy, newN.Get().GetTdsPolicy())
+	}
+}

--- a/test/model/model_tokenisation_response_model_test.go
+++ b/test/model/model_tokenisation_response_model_test.go
@@ -1,0 +1,143 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleTokAuthResult = "Y"
+var exampleTokBinCommercial = true
+var exampleTokBinDebit = true
+var exampleTokDescription = "desc"
+var exampleTokEci = "05"
+var exampleTokIdentifier = "id"
+var exampleTokMasked = "411111******1111"
+var exampleTokScheme = "VISA"
+var exampleTokSig = "sig"
+var exampleTokToken = "tok"
+
+func buildExampleTokenisationResponseModel() openapiclient.TokenisationResponseModel {
+	t := openapiclient.NewTokenisationResponseModel()
+	t.SetAuthenResult(exampleTokAuthResult)
+	t.SetBinCommercial(exampleTokBinCommercial)
+	t.SetBinDebit(exampleTokBinDebit)
+	t.SetBinDescription(exampleTokDescription)
+	t.SetEci(exampleTokEci)
+	t.SetIdentifier(exampleTokIdentifier)
+	t.SetMaskedpan(exampleTokMasked)
+	t.SetScheme(exampleTokScheme)
+	t.SetSigId(exampleTokSig)
+	t.SetToken(exampleTokToken)
+	return *t
+}
+
+func TestNewTokenisationResponseModel(t *testing.T) {
+	model := openapiclient.NewTokenisationResponseModel()
+	require.NotNil(t, model)
+	assert.False(t, model.HasScheme())
+}
+
+func TestNewTokenisationResponseModelWithDefaults(t *testing.T) {
+	model := openapiclient.NewTokenisationResponseModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAuthenResult())
+}
+
+func TestTokenisationResponseModelSetGetCycle(t *testing.T) {
+	model := openapiclient.NewTokenisationResponseModel()
+	model.SetAuthenResult(exampleTokAuthResult)
+	assert.True(t, model.HasAuthenResult())
+	assert.Equal(t, exampleTokAuthResult, model.GetAuthenResult())
+
+	model.SetBinCommercial(exampleTokBinCommercial)
+	assert.True(t, model.HasBinCommercial())
+	assert.Equal(t, exampleTokBinCommercial, model.GetBinCommercial())
+
+	model.SetBinDebit(exampleTokBinDebit)
+	assert.True(t, model.HasBinDebit())
+	assert.Equal(t, exampleTokBinDebit, model.GetBinDebit())
+
+	model.SetBinDescription(exampleTokDescription)
+	assert.True(t, model.HasBinDescription())
+	assert.Equal(t, exampleTokDescription, model.GetBinDescription())
+
+	model.SetEci(exampleTokEci)
+	assert.True(t, model.HasEci())
+	assert.Equal(t, exampleTokEci, model.GetEci())
+
+	model.SetIdentifier(exampleTokIdentifier)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleTokIdentifier, model.GetIdentifier())
+
+	model.SetMaskedpan(exampleTokMasked)
+	assert.True(t, model.HasMaskedpan())
+	assert.Equal(t, exampleTokMasked, model.GetMaskedpan())
+
+	model.SetScheme(exampleTokScheme)
+	assert.True(t, model.HasScheme())
+	assert.Equal(t, exampleTokScheme, model.GetScheme())
+
+	model.SetSigId(exampleTokSig)
+	assert.True(t, model.HasSigId())
+	assert.Equal(t, exampleTokSig, model.GetSigId())
+
+	model.SetToken(exampleTokToken)
+	assert.True(t, model.HasToken())
+	assert.Equal(t, exampleTokToken, model.GetToken())
+}
+
+func TestTokenisationResponseModelJSONRoundTrip(t *testing.T) {
+	model := buildExampleTokenisationResponseModel()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.TokenisationResponseModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasMaskedpan())
+	assert.Equal(t, exampleTokMasked, unmarshalled.GetMaskedpan())
+}
+
+func TestTokenisationResponseModelToMap(t *testing.T) {
+	model := buildExampleTokenisationResponseModel()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "token") {
+		assert.Equal(t, &exampleTokToken, m["token"])
+	}
+}
+
+func TestNullableTokenisationResponseModelGetSet(t *testing.T) {
+	base := buildExampleTokenisationResponseModel()
+	n := openapiclient.NullableTokenisationResponseModel{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableTokenisationResponseModelUnset(t *testing.T) {
+	base := buildExampleTokenisationResponseModel()
+	n := openapiclient.NewNullableTokenisationResponseModel(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableTokenisationResponseModelJSONRoundTrip(t *testing.T) {
+	base := buildExampleTokenisationResponseModel()
+	n := openapiclient.NewNullableTokenisationResponseModel(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableTokenisationResponseModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleTokEci, newN.Get().GetEci())
+	}
+}

--- a/test/model/model_void_request_test.go
+++ b/test/model/model_void_request_test.go
@@ -1,0 +1,98 @@
+package citypay
+
+import (
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+var exampleVoidIdentifier = "vid"
+var exampleVoidMid int32 = 9
+var exampleVoidTrans int32 = 22
+
+func buildExampleVoidRequest() openapiclient.VoidRequest {
+	r := openapiclient.NewVoidRequest(exampleVoidMid)
+	r.SetIdentifier(exampleVoidIdentifier)
+	r.SetTransno(exampleVoidTrans)
+	return *r
+}
+
+func TestNewVoidRequest(t *testing.T) {
+	model := openapiclient.NewVoidRequest(exampleVoidMid)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleVoidMid, model.GetMerchantid())
+	assert.False(t, model.HasIdentifier())
+}
+
+func TestNewVoidRequestWithDefaults(t *testing.T) {
+	model := openapiclient.NewVoidRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasMerchantid())
+}
+
+func TestVoidRequestSetGetCycle(t *testing.T) {
+	model := openapiclient.NewVoidRequest(exampleVoidMid)
+	model.SetIdentifier(exampleVoidIdentifier)
+	assert.True(t, model.HasIdentifier())
+	assert.Equal(t, exampleVoidIdentifier, model.GetIdentifier())
+
+	model.SetTransno(exampleVoidTrans)
+	assert.True(t, model.HasTransno())
+	assert.Equal(t, exampleVoidTrans, model.GetTransno())
+}
+
+func TestVoidRequestJSONRoundTrip(t *testing.T) {
+	model := buildExampleVoidRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
+
+	var unmarshalled openapiclient.VoidRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasIdentifier())
+	assert.Equal(t, exampleVoidIdentifier, unmarshalled.GetIdentifier())
+}
+
+func TestVoidRequestToMap(t *testing.T) {
+	model := buildExampleVoidRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, exampleVoidMid, m["merchantid"])
+	if assert.Contains(t, m, "identifier") {
+		assert.Equal(t, &exampleVoidIdentifier, m["identifier"])
+	}
+}
+
+func TestNullableVoidRequestGetSet(t *testing.T) {
+	base := buildExampleVoidRequest()
+	n := openapiclient.NullableVoidRequest{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
+}
+
+func TestNullableVoidRequestUnset(t *testing.T) {
+	base := buildExampleVoidRequest()
+	n := openapiclient.NewNullableVoidRequest(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
+}
+
+func TestNullableVoidRequestJSONRoundTrip(t *testing.T) {
+	base := buildExampleVoidRequest()
+	n := openapiclient.NewNullableVoidRequest(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var newN openapiclient.NullableVoidRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleVoidTrans, newN.Get().GetTransno())
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for ExternalMPI and ListMerchantsResponse
- cover MCC6012, Merchant and related batch report models
- test NetSummaryResponse, PaResAuthRequest and PaylinkAddress

## Testing
- `go test ./...` *(skipped as instructed)*

------
https://chatgpt.com/codex/tasks/task_b_6876573f30148331a24e460fff0d6e35