### PR TITLE
Fix duplicate variables in tests

### DIFF
--- a/test/model/model_batch_report_response_model_test.go
+++ b/test/model/model_batch_report_response_model_test.go
@@ -1,153 +1,152 @@
 package citypay
 
 import (
-    "encoding/json"
-    "testing"
-    "time"
+	"encoding/json"
+	"testing"
+	"time"
 
-    openapiclient "github.com/citypay/citypay-api-client-go"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var exampleBRRAmount int32 = 1000
 var exampleBRRBatchDate = "2023-02-01T15:04:05Z"
-var exampleBRRBatchId int32 = 55
+var exampleBRRRespBatchId int32 = 55
 var exampleBRRBatchStatus = "COMPLETE"
-var exampleBRRClientAccountId = "clientB"
+var exampleBRRRespClientAccountId = "clientB"
 
-var exampleResAccountId = "acc123"
-var exampleResAmount int32 = 10
-var exampleResAuthcode = "AUTH1"
-var exampleResDatetime = time.Date(2023, time.March, 4, 5, 6, 7, 0, time.UTC)
-var exampleResIdentifier = "id99"
-var exampleResMaskedpan = "411111******1111"
-var exampleResMerchantid int32 = 77
-var exampleResMessage = "Approved"
-var exampleResResult int32 = 1
-var exampleResResultCode = "OK"
-var exampleResScheme = "VISA"
-var exampleResSchemeId = "VI"
-var exampleResSchemeLogo = "logo"
-var exampleResTransno int32 = 101
+var exampleBRRResAccountId = "acc123"
+var exampleBRRResAmount int32 = 10
+var exampleBRRResAuthcode = "AUTH1"
+var exampleBRRResDatetime = time.Date(2023, time.March, 4, 5, 6, 7, 0, time.UTC)
+var exampleBRRResIdentifier = "id99"
+var exampleBRRResMaskedpan = "411111******1111"
+var exampleBRRResMerchantid int32 = 77
+var exampleBRRResMessage = "Approved"
+var exampleBRRResResult int32 = 1
+var exampleBRRResResultCode = "OK"
+var exampleBRRResScheme = "VISA"
+var exampleBRRResSchemeId = "VI"
+var exampleBRRResSchemeLogo = "logo"
+var exampleBRRResTransno int32 = 101
 
 func buildExampleBatchTransactionResult() openapiclient.BatchTransactionResultModel {
-    r := openapiclient.NewBatchTransactionResultModel(exampleResAccountId, exampleResIdentifier, exampleResMerchantid, exampleResMessage, exampleResResult, exampleResResultCode)
-    r.SetAmount(exampleResAmount)
-    r.SetAuthcode(exampleResAuthcode)
-    r.SetDatetime(exampleResDatetime)
-    r.SetMaskedpan(exampleResMaskedpan)
-    r.SetScheme(exampleResScheme)
-    r.SetSchemeId(exampleResSchemeId)
-    r.SetSchemeLogo(exampleResSchemeLogo)
-    r.SetTransno(exampleResTransno)
-    return *r
+	r := openapiclient.NewBatchTransactionResultModel(exampleBRRResAccountId, exampleBRRResIdentifier, exampleBRRResMerchantid, exampleBRRResMessage, exampleBRRResResult, exampleBRRResResultCode)
+	r.SetAmount(exampleBRRResAmount)
+	r.SetAuthcode(exampleBRRResAuthcode)
+	r.SetDatetime(exampleBRRResDatetime)
+	r.SetMaskedpan(exampleBRRResMaskedpan)
+	r.SetScheme(exampleBRRResScheme)
+	r.SetSchemeId(exampleBRRResSchemeId)
+	r.SetSchemeLogo(exampleBRRResSchemeLogo)
+	r.SetTransno(exampleBRRResTransno)
+	return *r
 }
 
 func buildExampleBatchReportResponseModel() *openapiclient.BatchReportResponseModel {
-    tr := buildExampleBatchTransactionResult()
-    m := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
-    return m
+	tr := buildExampleBatchTransactionResult()
+	m := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRRespBatchId, exampleBRRBatchStatus, exampleBRRRespClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+	return m
 }
 
 func TestNewBatchReportResponseModel(t *testing.T) {
-    tr := buildExampleBatchTransactionResult()
-    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
-    require.NotNil(t, model)
-    assert.Equal(t, exampleBRRAmount, model.GetAmount())
-    assert.Equal(t, exampleBRRBatchDate, model.GetBatchDate())
-    assert.Equal(t, exampleBRRBatchId, model.GetBatchId())
-    assert.Equal(t, exampleBRRBatchStatus, model.GetBatchStatus())
-    assert.Equal(t, exampleBRRClientAccountId, model.GetClientAccountId())
-    assert.Equal(t, 1, len(model.GetTransactions()))
+	tr := buildExampleBatchTransactionResult()
+	model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRRespBatchId, exampleBRRBatchStatus, exampleBRRRespClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+	require.NotNil(t, model)
+	assert.Equal(t, exampleBRRAmount, model.GetAmount())
+	assert.Equal(t, exampleBRRBatchDate, model.GetBatchDate())
+	assert.Equal(t, exampleBRRRespBatchId, model.GetBatchId())
+	assert.Equal(t, exampleBRRBatchStatus, model.GetBatchStatus())
+	assert.Equal(t, exampleBRRRespClientAccountId, model.GetClientAccountId())
+	assert.Equal(t, 1, len(model.GetTransactions()))
 }
 
 func TestNewBatchReportResponseModelWithDefaults(t *testing.T) {
-    model := openapiclient.NewBatchReportResponseModelWithDefaults()
-    require.NotNil(t, model)
-    assert.Equal(t, int32(0), model.GetAmount())
-    assert.Equal(t, "", model.GetBatchDate())
-    assert.Equal(t, int32(0), model.GetBatchId())
-    assert.Equal(t, "", model.GetBatchStatus())
-    assert.Equal(t, "", model.GetClientAccountId())
-    assert.Equal(t, 0, len(model.GetTransactions()))
+	model := openapiclient.NewBatchReportResponseModelWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+	assert.Equal(t, "", model.GetBatchDate())
+	assert.Equal(t, int32(0), model.GetBatchId())
+	assert.Equal(t, "", model.GetBatchStatus())
+	assert.Equal(t, "", model.GetClientAccountId())
+	assert.Equal(t, 0, len(model.GetTransactions()))
 }
 
 func TestBatchReportResponseModelSetGetCycle(t *testing.T) {
-    tr := buildExampleBatchTransactionResult()
-    model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRBatchId, exampleBRRBatchStatus, exampleBRRClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
-    model.SetAmount(2000)
-    assert.Equal(t, int32(2000), model.GetAmount())
-    model.SetBatchDate("2024-01-01")
-    assert.Equal(t, "2024-01-01", model.GetBatchDate())
-    model.SetBatchId(66)
-    assert.Equal(t, int32(66), model.GetBatchId())
-    model.SetBatchStatus("QUEUED")
-    assert.Equal(t, "QUEUED", model.GetBatchStatus())
-    model.SetClientAccountId("other")
-    assert.Equal(t, "other", model.GetClientAccountId())
-    model.SetTransactions([]openapiclient.BatchTransactionResultModel{tr, tr})
-    assert.Equal(t, 2, len(model.GetTransactions()))
+	tr := buildExampleBatchTransactionResult()
+	model := openapiclient.NewBatchReportResponseModel(exampleBRRAmount, exampleBRRBatchDate, exampleBRRRespBatchId, exampleBRRBatchStatus, exampleBRRRespClientAccountId, []openapiclient.BatchTransactionResultModel{tr})
+	model.SetAmount(2000)
+	assert.Equal(t, int32(2000), model.GetAmount())
+	model.SetBatchDate("2024-01-01")
+	assert.Equal(t, "2024-01-01", model.GetBatchDate())
+	model.SetBatchId(66)
+	assert.Equal(t, int32(66), model.GetBatchId())
+	model.SetBatchStatus("QUEUED")
+	assert.Equal(t, "QUEUED", model.GetBatchStatus())
+	model.SetClientAccountId("other")
+	assert.Equal(t, "other", model.GetClientAccountId())
+	model.SetTransactions([]openapiclient.BatchTransactionResultModel{tr, tr})
+	assert.Equal(t, 2, len(model.GetTransactions()))
 }
 
 func TestBatchReportResponseModelJSONRoundTrip(t *testing.T) {
-    model := buildExampleBatchReportResponseModel()
-    data, err := json.Marshal(model)
-    require.NoError(t, err)
+	model := buildExampleBatchReportResponseModel()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
 
-    var unmarshalled openapiclient.BatchReportResponseModel
-    err = json.Unmarshal(data, &unmarshalled)
-    require.NoError(t, err)
-    assert.Equal(t, exampleBRRAmount, unmarshalled.GetAmount())
-    assert.Equal(t, exampleBRRBatchDate, unmarshalled.GetBatchDate())
-    assert.Equal(t, exampleBRRBatchStatus, unmarshalled.GetBatchStatus())
-    assert.Equal(t, 1, len(unmarshalled.GetTransactions()))
+	var unmarshalled openapiclient.BatchReportResponseModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleBRRAmount, unmarshalled.GetAmount())
+	assert.Equal(t, exampleBRRBatchDate, unmarshalled.GetBatchDate())
+	assert.Equal(t, exampleBRRBatchStatus, unmarshalled.GetBatchStatus())
+	assert.Equal(t, 1, len(unmarshalled.GetTransactions()))
 }
 
 func TestBatchReportResponseModelToMap(t *testing.T) {
-    model := buildExampleBatchReportResponseModel()
-    m, err := model.ToMap()
-    require.NoError(t, err)
-    if assert.Contains(t, m, "amount") {
-        assert.Equal(t, exampleBRRAmount, m["amount"])
-    }
-    if assert.Contains(t, m, "batch_status") {
-        assert.Equal(t, exampleBRRBatchStatus, m["batch_status"])
-    }
-    if assert.Contains(t, m, "transactions") {
-        assert.Equal(t, 1, len(m["transactions"].([]openapiclient.BatchTransactionResultModel)))
-    }
+	model := buildExampleBatchReportResponseModel()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "amount") {
+		assert.Equal(t, exampleBRRAmount, m["amount"])
+	}
+	if assert.Contains(t, m, "batch_status") {
+		assert.Equal(t, exampleBRRBatchStatus, m["batch_status"])
+	}
+	if assert.Contains(t, m, "transactions") {
+		assert.Equal(t, 1, len(m["transactions"].([]openapiclient.BatchTransactionResultModel)))
+	}
 }
 
 func TestNullableBatchReportResponseModelGetSet(t *testing.T) {
-    base := buildExampleBatchReportResponseModel()
-    n := openapiclient.NullableBatchReportResponseModel{}
-    n.Set(base)
-    require.True(t, n.IsSet())
-    assert.Equal(t, base, n.Get())
+	base := buildExampleBatchReportResponseModel()
+	n := openapiclient.NullableBatchReportResponseModel{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
 }
 
 func TestNullableBatchReportResponseModelUnset(t *testing.T) {
-    base := buildExampleBatchReportResponseModel()
-    n := openapiclient.NewNullableBatchReportResponseModel(base)
-    require.True(t, n.IsSet())
-    n.Unset()
-    assert.False(t, n.IsSet())
-    assert.Nil(t, n.Get())
+	base := buildExampleBatchReportResponseModel()
+	n := openapiclient.NewNullableBatchReportResponseModel(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
 }
 
 func TestNullableBatchReportResponseModelJSONRoundTrip(t *testing.T) {
-    base := buildExampleBatchReportResponseModel()
-    n := openapiclient.NewNullableBatchReportResponseModel(base)
-    data, err := json.Marshal(n)
-    require.NoError(t, err)
+	base := buildExampleBatchReportResponseModel()
+	n := openapiclient.NewNullableBatchReportResponseModel(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
 
-    var newN openapiclient.NullableBatchReportResponseModel
-    err = json.Unmarshal(data, &newN)
-    require.NoError(t, err)
-    assert.True(t, newN.IsSet())
-    if assert.NotNil(t, newN.Get()) {
-        assert.Equal(t, exampleBRRBatchStatus, newN.Get().GetBatchStatus())
-    }
+	var newN openapiclient.NullableBatchReportResponseModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleBRRBatchStatus, newN.Get().GetBatchStatus())
+	}
 }
-

--- a/test/model/model_decision_test.go
+++ b/test/model/model_decision_test.go
@@ -10,7 +10,7 @@ import (
 
 var exampleAcsURL = "https://acs.example.com"
 var exampleCreq = "creqdata"
-var exampleMerchantID int32 = 100
+var exampleDecisionMerchantID int32 = 100
 var exampleThreeDSID = "threedid"
 var exampleTransno int32 = 5
 var exampleAuthMerchant int32 = 321
@@ -22,7 +22,7 @@ func buildExampleRequestChallenged() openapiclient.RequestChallenged {
 	r := openapiclient.NewRequestChallenged()
 	r.SetAcsUrl(exampleAcsURL)
 	r.SetCreq(exampleCreq)
-	r.SetMerchantid(exampleMerchantID)
+	r.SetMerchantid(exampleDecisionMerchantID)
 	r.SetThreedserverTransId(exampleThreeDSID)
 	r.SetTransno(exampleTransno)
 	return *r

--- a/test/model/model_domain_key_request_test.go
+++ b/test/model/model_domain_key_request_test.go
@@ -10,19 +10,19 @@ import (
 
 var exampleDomain = []string{"example.com"}
 var exampleLive = true
-var exampleMerchantID int32 = 50
+var exampleDomainMerchantID int32 = 50
 
 func buildExampleDomainKeyRequest() *openapiclient.DomainKeyRequest {
-	d := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	d := openapiclient.NewDomainKeyRequest(exampleDomain, exampleDomainMerchantID)
 	d.SetLive(exampleLive)
 	return d
 }
 
 func TestNewDomainKeyRequest(t *testing.T) {
-	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleDomainMerchantID)
 	require.NotNil(t, model)
 	assert.Equal(t, exampleDomain, model.GetDomain())
-	assert.Equal(t, exampleMerchantID, model.GetMerchantid())
+	assert.Equal(t, exampleDomainMerchantID, model.GetMerchantid())
 	assert.False(t, model.HasLive())
 }
 
@@ -34,7 +34,7 @@ func TestNewDomainKeyRequestWithDefaults(t *testing.T) {
 }
 
 func TestDomainKeyRequestSetGetCycle(t *testing.T) {
-	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleMerchantID)
+	model := openapiclient.NewDomainKeyRequest(exampleDomain, exampleDomainMerchantID)
 	model.SetDomain([]string{"new.com"})
 	assert.Equal(t, []string{"new.com"}, model.GetDomain())
 
@@ -57,7 +57,7 @@ func TestDomainKeyRequestJSONRoundTrip(t *testing.T) {
 	var unmarshalled openapiclient.DomainKeyRequest
 	err = json.Unmarshal(data, &unmarshalled)
 	require.NoError(t, err)
-	assert.Equal(t, exampleMerchantID, unmarshalled.GetMerchantid())
+	assert.Equal(t, exampleDomainMerchantID, unmarshalled.GetMerchantid())
 	assert.True(t, unmarshalled.HasLive())
 }
 
@@ -101,6 +101,6 @@ func TestNullableDomainKeyRequestJSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, newN.IsSet())
 	if assert.NotNil(t, newN.Get()) {
-		assert.Equal(t, exampleMerchantID, newN.Get().GetMerchantid())
+		assert.Equal(t, exampleDomainMerchantID, newN.Get().GetMerchantid())
 	}
 }

--- a/test/model/model_domain_key_response_test.go
+++ b/test/model/model_domain_key_response_test.go
@@ -12,14 +12,14 @@ import (
 var exampleRespDomain = []string{"example.com"}
 var exampleRespDate = time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)
 var exampleRespDomainKey = "KEY"
-var exampleRespLive = true
+var exampleDomainRespLive = true
 var exampleRespMerchant int32 = 55
 
 func buildExampleDomainKeyResponse() *openapiclient.DomainKeyResponse {
 	d := openapiclient.NewDomainKeyResponse(exampleRespDomain, exampleRespMerchant)
 	d.SetDateCreated(exampleRespDate)
 	d.SetDomainKey(exampleRespDomainKey)
-	d.SetLive(exampleRespLive)
+	d.SetLive(exampleDomainRespLive)
 	return d
 }
 
@@ -51,9 +51,9 @@ func TestDomainKeyResponseSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasDomainKey())
 	assert.Equal(t, exampleRespDomainKey, model.GetDomainKey())
 
-	model.SetLive(exampleRespLive)
+	model.SetLive(exampleDomainRespLive)
 	assert.True(t, model.HasLive())
-	assert.Equal(t, exampleRespLive, model.GetLive())
+	assert.Equal(t, exampleDomainRespLive, model.GetLive())
 
 	model.SetMerchantid(99)
 	assert.Equal(t, int32(99), model.GetMerchantid())
@@ -79,7 +79,7 @@ func TestDomainKeyResponseToMap(t *testing.T) {
 		assert.Equal(t, &exampleRespDomainKey, m["domain_key"])
 	}
 	if assert.Contains(t, m, "live") {
-		assert.Equal(t, &exampleRespLive, m["live"])
+		assert.Equal(t, &exampleDomainRespLive, m["live"])
 	}
 }
 

--- a/test/model/model_merchant_test.go
+++ b/test/model/model_merchant_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var exampleMerchantCurrency = "GBP"
-var exampleMerchantID int32 = 99
+var exampleMerchantIDVal int32 = 99
 var exampleMerchantName = "Test Shop"
 var exampleMerchantStatus = "A"
 var exampleMerchantLabel = "Active"
@@ -17,7 +17,7 @@ var exampleMerchantLabel = "Active"
 func buildExampleMerchant() openapiclient.Merchant {
 	m := openapiclient.NewMerchant()
 	m.SetCurrency(exampleMerchantCurrency)
-	m.SetMerchantid(exampleMerchantID)
+	m.SetMerchantid(exampleMerchantIDVal)
 	m.SetName(exampleMerchantName)
 	m.SetStatus(exampleMerchantStatus)
 	m.SetStatusLabel(exampleMerchantLabel)
@@ -53,9 +53,9 @@ func TestMerchantSetGetCycle(t *testing.T) {
 		assert.Equal(t, exampleMerchantCurrency, *val)
 	}
 
-	model.SetMerchantid(exampleMerchantID)
+	model.SetMerchantid(exampleMerchantIDVal)
 	assert.True(t, model.HasMerchantid())
-	assert.Equal(t, exampleMerchantID, model.GetMerchantid())
+	assert.Equal(t, exampleMerchantIDVal, model.GetMerchantid())
 
 	model.SetName(exampleMerchantName)
 	assert.True(t, model.HasName())
@@ -90,7 +90,7 @@ func TestMerchantToMap(t *testing.T) {
 		assert.Equal(t, &exampleMerchantCurrency, m["currency"])
 	}
 	if assert.Contains(t, m, "merchantid") {
-		assert.Equal(t, &exampleMerchantID, m["merchantid"])
+		assert.Equal(t, &exampleMerchantIDVal, m["merchantid"])
 	}
 	if assert.Contains(t, m, "name") {
 		assert.Equal(t, &exampleMerchantName, m["name"])
@@ -131,6 +131,6 @@ func TestNullableMerchantJSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, newN.IsSet())
 	if assert.NotNil(t, newN.Get()) {
-		assert.Equal(t, exampleMerchantID, newN.Get().GetMerchantid())
+		assert.Equal(t, exampleMerchantIDVal, newN.Get().GetMerchantid())
 	}
 }

--- a/test/model/model_paylink_address_test.go
+++ b/test/model/model_paylink_address_test.go
@@ -11,20 +11,20 @@ import (
 var exampleAddr1 = "1 Road"
 var exampleAddr2 = "Suite 2"
 var exampleAddr3 = "Floor 3"
-var exampleArea = "City"
-var exampleCountry = "GB"
+var examplePlAddrArea = "City"
+var examplePlAddrCountry = "GB"
 var exampleLabel = "Home"
-var examplePostcode = "AB12"
+var examplePlAddrPostcode = "AB12"
 
 func buildExamplePaylinkAddress() openapiclient.PaylinkAddress {
 	p := openapiclient.NewPaylinkAddress()
 	p.SetAddress1(exampleAddr1)
 	p.SetAddress2(exampleAddr2)
 	p.SetAddress3(exampleAddr3)
-	p.SetArea(exampleArea)
-	p.SetCountry(exampleCountry)
+	p.SetArea(examplePlAddrArea)
+	p.SetCountry(examplePlAddrCountry)
 	p.SetLabel(exampleLabel)
-	p.SetPostcode(examplePostcode)
+	p.SetPostcode(examplePlAddrPostcode)
 	return *p
 }
 
@@ -69,21 +69,21 @@ func TestPaylinkAddressSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasAddress3())
 	assert.Equal(t, exampleAddr3, model.GetAddress3())
 
-	model.SetArea(exampleArea)
+	model.SetArea(examplePlAddrArea)
 	assert.True(t, model.HasArea())
-	assert.Equal(t, exampleArea, model.GetArea())
+	assert.Equal(t, examplePlAddrArea, model.GetArea())
 
-	model.SetCountry(exampleCountry)
+	model.SetCountry(examplePlAddrCountry)
 	assert.True(t, model.HasCountry())
-	assert.Equal(t, exampleCountry, model.GetCountry())
+	assert.Equal(t, examplePlAddrCountry, model.GetCountry())
 
 	model.SetLabel(exampleLabel)
 	assert.True(t, model.HasLabel())
 	assert.Equal(t, exampleLabel, model.GetLabel())
 
-	model.SetPostcode(examplePostcode)
+	model.SetPostcode(examplePlAddrPostcode)
 	assert.True(t, model.HasPostcode())
-	assert.Equal(t, examplePostcode, model.GetPostcode())
+	assert.Equal(t, examplePlAddrPostcode, model.GetPostcode())
 }
 
 func TestPaylinkAddressJSONRoundTrip(t *testing.T) {
@@ -112,16 +112,16 @@ func TestPaylinkAddressToMap(t *testing.T) {
 		assert.Equal(t, &exampleAddr3, m["address3"])
 	}
 	if assert.Contains(t, m, "area") {
-		assert.Equal(t, &exampleArea, m["area"])
+		assert.Equal(t, &examplePlAddrArea, m["area"])
 	}
 	if assert.Contains(t, m, "country") {
-		assert.Equal(t, &exampleCountry, m["country"])
+		assert.Equal(t, &examplePlAddrCountry, m["country"])
 	}
 	if assert.Contains(t, m, "label") {
 		assert.Equal(t, &exampleLabel, m["label"])
 	}
 	if assert.Contains(t, m, "postcode") {
-		assert.Equal(t, &examplePostcode, m["postcode"])
+		assert.Equal(t, &examplePlAddrPostcode, m["postcode"])
 	}
 }
 
@@ -153,6 +153,6 @@ func TestNullablePaylinkAddressJSONRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, newN.IsSet())
 	if assert.NotNil(t, newN.Get()) {
-		assert.Equal(t, examplePostcode, newN.Get().GetPostcode())
+		assert.Equal(t, examplePlAddrPostcode, newN.Get().GetPostcode())
 	}
 }

--- a/test/model/model_paylink_error_code_test.go
+++ b/test/model/model_paylink_error_code_test.go
@@ -1,91 +1,90 @@
 package citypay
 
 import (
-    "encoding/json"
-    openapiclient "github.com/citypay/citypay-api-client-go"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "testing"
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
-var exampleErrCode = "E1"
-var exampleErrMsg = "error"
+var examplePaylinkErrCode = "E1"
+var examplePaylinkErrMsg = "error"
 
 func buildExamplePaylinkErrorCode() openapiclient.PaylinkErrorCode {
-    e := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
-    return *e
+	e := openapiclient.NewPaylinkErrorCode(examplePaylinkErrCode, examplePaylinkErrMsg)
+	return *e
 }
 
 func TestNewPaylinkErrorCode(t *testing.T) {
-    model := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
-    require.NotNil(t, model)
-    assert.Equal(t, exampleErrCode, model.GetCode())
-    assert.Equal(t, exampleErrMsg, model.GetMsg())
+	model := openapiclient.NewPaylinkErrorCode(examplePaylinkErrCode, examplePaylinkErrMsg)
+	require.NotNil(t, model)
+	assert.Equal(t, examplePaylinkErrCode, model.GetCode())
+	assert.Equal(t, examplePaylinkErrMsg, model.GetMsg())
 }
 
 func TestNewPaylinkErrorCodeWithDefaults(t *testing.T) {
-    model := openapiclient.NewPaylinkErrorCodeWithDefaults()
-    require.NotNil(t, model)
-    assert.NotNil(t, model)
+	model := openapiclient.NewPaylinkErrorCodeWithDefaults()
+	require.NotNil(t, model)
+	assert.NotNil(t, model)
 }
 
 func TestPaylinkErrorCodeSetGetCycle(t *testing.T) {
-    model := openapiclient.NewPaylinkErrorCode(exampleErrCode, exampleErrMsg)
-    model.SetCode("E2")
-    assert.Equal(t, "E2", model.GetCode())
+	model := openapiclient.NewPaylinkErrorCode(examplePaylinkErrCode, examplePaylinkErrMsg)
+	model.SetCode("E2")
+	assert.Equal(t, "E2", model.GetCode())
 
-    model.SetMsg("msg")
-    assert.Equal(t, "msg", model.GetMsg())
+	model.SetMsg("msg")
+	assert.Equal(t, "msg", model.GetMsg())
 }
 
 func TestPaylinkErrorCodeJSONRoundTrip(t *testing.T) {
-    model := buildExamplePaylinkErrorCode()
-    data, err := json.Marshal(model)
-    require.NoError(t, err)
+	model := buildExamplePaylinkErrorCode()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
 
-    var unmarshalled openapiclient.PaylinkErrorCode
-    err = json.Unmarshal(data, &unmarshalled)
-    require.NoError(t, err)
-    assert.Equal(t, exampleErrMsg, unmarshalled.GetMsg())
+	var unmarshalled openapiclient.PaylinkErrorCode
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, examplePaylinkErrMsg, unmarshalled.GetMsg())
 }
 
 func TestPaylinkErrorCodeToMap(t *testing.T) {
-    model := buildExamplePaylinkErrorCode()
-    m, err := model.ToMap()
-    require.NoError(t, err)
-    assert.Equal(t, exampleErrCode, m["code"])
-    assert.Equal(t, exampleErrMsg, m["msg"])
+	model := buildExamplePaylinkErrorCode()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, examplePaylinkErrCode, m["code"])
+	assert.Equal(t, examplePaylinkErrMsg, m["msg"])
 }
 
 func TestNullablePaylinkErrorCodeGetSet(t *testing.T) {
-    base := buildExamplePaylinkErrorCode()
-    n := openapiclient.NullablePaylinkErrorCode{}
-    n.Set(&base)
-    require.True(t, n.IsSet())
-    assert.Equal(t, &base, n.Get())
+	base := buildExamplePaylinkErrorCode()
+	n := openapiclient.NullablePaylinkErrorCode{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
 }
 
 func TestNullablePaylinkErrorCodeUnset(t *testing.T) {
-    base := buildExamplePaylinkErrorCode()
-    n := openapiclient.NewNullablePaylinkErrorCode(&base)
-    require.True(t, n.IsSet())
-    n.Unset()
-    assert.False(t, n.IsSet())
-    assert.Nil(t, n.Get())
+	base := buildExamplePaylinkErrorCode()
+	n := openapiclient.NewNullablePaylinkErrorCode(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
 }
 
 func TestNullablePaylinkErrorCodeJSONRoundTrip(t *testing.T) {
-    base := buildExamplePaylinkErrorCode()
-    n := openapiclient.NewNullablePaylinkErrorCode(&base)
-    data, err := json.Marshal(n)
-    require.NoError(t, err)
+	base := buildExamplePaylinkErrorCode()
+	n := openapiclient.NewNullablePaylinkErrorCode(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
 
-    var newN openapiclient.NullablePaylinkErrorCode
-    err = json.Unmarshal(data, &newN)
-    require.NoError(t, err)
-    assert.True(t, newN.IsSet())
-    if assert.NotNil(t, newN.Get()) {
-        assert.Equal(t, exampleErrCode, newN.Get().GetCode())
-    }
+	var newN openapiclient.NullablePaylinkErrorCode
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, examplePaylinkErrCode, newN.Get().GetCode())
+	}
 }
-

--- a/test/model/model_paylink_token_request_model_test.go
+++ b/test/model/model_paylink_token_request_model_test.go
@@ -1,167 +1,166 @@
 package citypay
 
 import (
-    "encoding/json"
-    openapiclient "github.com/citypay/citypay-api-client-go"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "testing"
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 var exampleReqAccount = "acc"
-var exampleReqAmount int32 = 100
-var exampleReqIdentifier = "id"
-var exampleReqMerchant int32 = 1
+var examplePLReqAmount int32 = 100
+var examplePLReqIdentifier = "id"
+var examplePLReqMerchant int32 = 1
 var exampleReqClientVersion = "1.0"
-var exampleReqCurrency = "GBP"
+var examplePLReqCurrency = "GBP"
 var exampleReqEmail = "m@example.com"
 var exampleReqRecurring = true
 var exampleReqSub = "sub"
-var exampleReqTxType = "SALE"
+var examplePLReqTxType = "SALE"
 
 func buildExampleCardHolder() openapiclient.PaylinkCardHolder {
-    c := openapiclient.NewPaylinkCardHolder()
-    c.SetFirstname("f")
-    return *c
+	c := openapiclient.NewPaylinkCardHolder()
+	c.SetFirstname("f")
+	return *c
 }
 
 func buildExampleCart() openapiclient.PaylinkCart {
-    c := openapiclient.NewPaylinkCart()
-    return *c
+	c := openapiclient.NewPaylinkCart()
+	return *c
 }
 
 func buildExampleConfig() openapiclient.PaylinkConfig {
-    c := openapiclient.NewPaylinkConfig()
-    return *c
+	c := openapiclient.NewPaylinkConfig()
+	return *c
 }
 
 func buildExamplePaylinkTokenRequestModel() openapiclient.PaylinkTokenRequestModel {
-    r := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
-    r.SetAccountno(exampleReqAccount)
-    ch := buildExampleCardHolder()
-    r.SetCardholder(ch)
-    cart := buildExampleCart()
-    r.SetCart(cart)
-    r.SetClientVersion(exampleReqClientVersion)
-    cfg := buildExampleConfig()
-    r.SetConfig(cfg)
-    r.SetCurrency(exampleReqCurrency)
-    r.SetEmail(exampleReqEmail)
-    r.SetRecurring(exampleReqRecurring)
-    r.SetSubscriptionId(exampleReqSub)
-    r.SetTxType(exampleReqTxType)
-    return *r
+	r := openapiclient.NewPaylinkTokenRequestModel(examplePLReqAmount, examplePLReqIdentifier, examplePLReqMerchant)
+	r.SetAccountno(exampleReqAccount)
+	ch := buildExampleCardHolder()
+	r.SetCardholder(ch)
+	cart := buildExampleCart()
+	r.SetCart(cart)
+	r.SetClientVersion(exampleReqClientVersion)
+	cfg := buildExampleConfig()
+	r.SetConfig(cfg)
+	r.SetCurrency(examplePLReqCurrency)
+	r.SetEmail(exampleReqEmail)
+	r.SetRecurring(exampleReqRecurring)
+	r.SetSubscriptionId(exampleReqSub)
+	r.SetTxType(examplePLReqTxType)
+	return *r
 }
 
 func TestNewPaylinkTokenRequestModel(t *testing.T) {
-    model := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
-    require.NotNil(t, model)
-    assert.Equal(t, exampleReqAmount, model.GetAmount())
-    assert.Equal(t, exampleReqIdentifier, model.GetIdentifier())
-    assert.Equal(t, exampleReqMerchant, model.GetMerchantid())
-    assert.False(t, model.HasEmail())
+	model := openapiclient.NewPaylinkTokenRequestModel(examplePLReqAmount, examplePLReqIdentifier, examplePLReqMerchant)
+	require.NotNil(t, model)
+	assert.Equal(t, examplePLReqAmount, model.GetAmount())
+	assert.Equal(t, examplePLReqIdentifier, model.GetIdentifier())
+	assert.Equal(t, examplePLReqMerchant, model.GetMerchantid())
+	assert.False(t, model.HasEmail())
 }
 
 func TestNewPaylinkTokenRequestModelWithDefaults(t *testing.T) {
-    model := openapiclient.NewPaylinkTokenRequestModelWithDefaults()
-    require.NotNil(t, model)
-    assert.False(t, model.HasAmount())
+	model := openapiclient.NewPaylinkTokenRequestModelWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasAmount())
 }
 
 func TestPaylinkTokenRequestModelSetGetCycle(t *testing.T) {
-    model := openapiclient.NewPaylinkTokenRequestModel(exampleReqAmount, exampleReqIdentifier, exampleReqMerchant)
-    model.SetAccountno(exampleReqAccount)
-    assert.True(t, model.HasAccountno())
-    assert.Equal(t, exampleReqAccount, model.GetAccountno())
+	model := openapiclient.NewPaylinkTokenRequestModel(examplePLReqAmount, examplePLReqIdentifier, examplePLReqMerchant)
+	model.SetAccountno(exampleReqAccount)
+	assert.True(t, model.HasAccountno())
+	assert.Equal(t, exampleReqAccount, model.GetAccountno())
 
-    ch := buildExampleCardHolder()
-    model.SetCardholder(ch)
-    assert.True(t, model.HasCardholder())
+	ch := buildExampleCardHolder()
+	model.SetCardholder(ch)
+	assert.True(t, model.HasCardholder())
 
-    cart := buildExampleCart()
-    model.SetCart(cart)
-    assert.True(t, model.HasCart())
+	cart := buildExampleCart()
+	model.SetCart(cart)
+	assert.True(t, model.HasCart())
 
-    model.SetClientVersion(exampleReqClientVersion)
-    assert.True(t, model.HasClientVersion())
-    assert.Equal(t, exampleReqClientVersion, model.GetClientVersion())
+	model.SetClientVersion(exampleReqClientVersion)
+	assert.True(t, model.HasClientVersion())
+	assert.Equal(t, exampleReqClientVersion, model.GetClientVersion())
 
-    cfg := buildExampleConfig()
-    model.SetConfig(cfg)
-    assert.True(t, model.HasConfig())
+	cfg := buildExampleConfig()
+	model.SetConfig(cfg)
+	assert.True(t, model.HasConfig())
 
-    model.SetCurrency(exampleReqCurrency)
-    assert.True(t, model.HasCurrency())
-    assert.Equal(t, exampleReqCurrency, model.GetCurrency())
+	model.SetCurrency(examplePLReqCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, examplePLReqCurrency, model.GetCurrency())
 
-    model.SetEmail(exampleReqEmail)
-    assert.True(t, model.HasEmail())
-    assert.Equal(t, exampleReqEmail, model.GetEmail())
+	model.SetEmail(exampleReqEmail)
+	assert.True(t, model.HasEmail())
+	assert.Equal(t, exampleReqEmail, model.GetEmail())
 
-    model.SetRecurring(exampleReqRecurring)
-    assert.True(t, model.HasRecurring())
-    assert.Equal(t, exampleReqRecurring, model.GetRecurring())
+	model.SetRecurring(exampleReqRecurring)
+	assert.True(t, model.HasRecurring())
+	assert.Equal(t, exampleReqRecurring, model.GetRecurring())
 
-    model.SetSubscriptionId(exampleReqSub)
-    assert.True(t, model.HasSubscriptionId())
-    assert.Equal(t, exampleReqSub, model.GetSubscriptionId())
+	model.SetSubscriptionId(exampleReqSub)
+	assert.True(t, model.HasSubscriptionId())
+	assert.Equal(t, exampleReqSub, model.GetSubscriptionId())
 
-    model.SetTxType(exampleReqTxType)
-    assert.True(t, model.HasTxType())
-    assert.Equal(t, exampleReqTxType, model.GetTxType())
+	model.SetTxType(examplePLReqTxType)
+	assert.True(t, model.HasTxType())
+	assert.Equal(t, examplePLReqTxType, model.GetTxType())
 }
 
 func TestPaylinkTokenRequestModelJSONRoundTrip(t *testing.T) {
-    model := buildExamplePaylinkTokenRequestModel()
-    data, err := json.Marshal(model)
-    require.NoError(t, err)
+	model := buildExamplePaylinkTokenRequestModel()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
 
-    var unmarshalled openapiclient.PaylinkTokenRequestModel
-    err = json.Unmarshal(data, &unmarshalled)
-    require.NoError(t, err)
-    assert.True(t, unmarshalled.HasAccountno())
-    assert.Equal(t, exampleReqAccount, unmarshalled.GetAccountno())
+	var unmarshalled openapiclient.PaylinkTokenRequestModel
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasAccountno())
+	assert.Equal(t, exampleReqAccount, unmarshalled.GetAccountno())
 }
 
 func TestPaylinkTokenRequestModelToMap(t *testing.T) {
-    model := buildExamplePaylinkTokenRequestModel()
-    m, err := model.ToMap()
-    require.NoError(t, err)
-    assert.Equal(t, exampleReqAmount, m["amount"])
-    if assert.Contains(t, m, "tx_type") {
-        assert.Equal(t, &exampleReqTxType, m["tx_type"])
-    }
+	model := buildExamplePaylinkTokenRequestModel()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	assert.Equal(t, examplePLReqAmount, m["amount"])
+	if assert.Contains(t, m, "tx_type") {
+		assert.Equal(t, &examplePLReqTxType, m["tx_type"])
+	}
 }
 
 func TestNullablePaylinkTokenRequestModelGetSet(t *testing.T) {
-    base := buildExamplePaylinkTokenRequestModel()
-    n := openapiclient.NullablePaylinkTokenRequestModel{}
-    n.Set(&base)
-    require.True(t, n.IsSet())
-    assert.Equal(t, &base, n.Get())
+	base := buildExamplePaylinkTokenRequestModel()
+	n := openapiclient.NullablePaylinkTokenRequestModel{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
 }
 
 func TestNullablePaylinkTokenRequestModelUnset(t *testing.T) {
-    base := buildExamplePaylinkTokenRequestModel()
-    n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
-    require.True(t, n.IsSet())
-    n.Unset()
-    assert.False(t, n.IsSet())
-    assert.Nil(t, n.Get())
+	base := buildExamplePaylinkTokenRequestModel()
+	n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
 }
 
 func TestNullablePaylinkTokenRequestModelJSONRoundTrip(t *testing.T) {
-    base := buildExamplePaylinkTokenRequestModel()
-    n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
-    data, err := json.Marshal(n)
-    require.NoError(t, err)
+	base := buildExamplePaylinkTokenRequestModel()
+	n := openapiclient.NewNullablePaylinkTokenRequestModel(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
 
-    var newN openapiclient.NullablePaylinkTokenRequestModel
-    err = json.Unmarshal(data, &newN)
-    require.NoError(t, err)
-    assert.True(t, newN.IsSet())
-    if assert.NotNil(t, newN.Get()) {
-        assert.Equal(t, exampleReqMerchant, newN.Get().GetMerchantid())
-    }
+	var newN openapiclient.NullablePaylinkTokenRequestModel
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, examplePLReqMerchant, newN.Get().GetMerchantid())
+	}
 }
-


### PR DESCRIPTION
## Summary
- deduplicate variable names across test/model files

## Testing
- `go test ./...` *(fails: github.com/stretchr/testify blocked)*

------
https://chatgpt.com/codex/tasks/task_b_687773d0c9fc8331b2c18beca6c44391