### PR TITLE
Fix duplicate helper names in model tests

### DIFF
--- a/test/model/model_auth_request_test.go
+++ b/test/model/model_auth_request_test.go
@@ -1,12 +1,12 @@
 package citypay
 
 import (
-    "encoding/json"
-    "testing"
+	"encoding/json"
+	"testing"
 
-    openapiclient "github.com/citypay/citypay-api-client-go"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var exampleReqAmount int32 = 10000
@@ -27,188 +27,187 @@ var exampleReqTransType = "SALE"
 var exampleReqTags = []string{"one", "two"}
 
 func buildExampleEventData() openapiclient.EventDataModel {
-    e := openapiclient.NewEventDataModel()
-    e.SetEventId("EVT")
-    return *e
+	e := openapiclient.NewEventDataModel()
+	e.SetEventId("EVT")
+	return *e
 }
 
-func buildExampleExternalMPI() openapiclient.ExternalMPI {
-    e := openapiclient.NewExternalMPI()
-    e.SetEnrolled("Y")
-    return *e
+func buildAuthExternalMPI() openapiclient.ExternalMPI {
+	e := openapiclient.NewExternalMPI()
+	e.SetEnrolled("Y")
+	return *e
 }
 
 func buildExampleMcc6012() openapiclient.MCC6012 {
-    m := openapiclient.NewMCC6012()
-    m.SetRecipientLastname("Smith")
-    return *m
+	m := openapiclient.NewMCC6012()
+	m.SetRecipientLastname("Smith")
+	return *m
 }
 
-func buildExampleThreeDSecure() openapiclient.ThreeDSecure {
-    t := openapiclient.NewThreeDSecure()
-    t.SetTdsPolicy("1")
-    return *t
+func buildAuthThreeDSecure() openapiclient.ThreeDSecure {
+	t := openapiclient.NewThreeDSecure()
+	t.SetTdsPolicy("1")
+	return *t
 }
 
 func buildExampleAuthRequest() *openapiclient.AuthRequest {
-    r := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
-    r.SetAirlineData(*buildExampleAdvice())
-    r.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
-    r.SetBillTo(buildExampleContact())
-    r.SetCsc(exampleReqCsc)
-    r.SetCscPolicy(exampleReqCscPolicy)
-    r.SetCurrency(exampleReqCurrency)
-    r.SetDuplicatePolicy(exampleReqDuplicatePolicy)
-    r.SetEventManagement(buildExampleEventData())
-    r.SetExternalMpi(buildExampleExternalMPI())
-    r.SetMatchAvsa(exampleReqMatchAvsa)
-    r.SetMcc6012(buildExampleMcc6012())
-    r.SetNameOnCard(exampleReqNameOnCard)
-    r.SetShipTo(buildExampleContact())
-    r.SetTag(exampleReqTags)
-    r.SetThreedsecure(buildExampleThreeDSecure())
-    r.SetTransInfo(exampleReqTransInfo)
-    r.SetTransType(exampleReqTransType)
-    return r
+	r := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+	r.SetAirlineData(*buildExampleAdvice())
+	r.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+	r.SetBillTo(buildExampleContact())
+	r.SetCsc(exampleReqCsc)
+	r.SetCscPolicy(exampleReqCscPolicy)
+	r.SetCurrency(exampleReqCurrency)
+	r.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+	r.SetEventManagement(buildExampleEventData())
+	r.SetExternalMpi(buildAuthExternalMPI())
+	r.SetMatchAvsa(exampleReqMatchAvsa)
+	r.SetMcc6012(buildExampleMcc6012())
+	r.SetNameOnCard(exampleReqNameOnCard)
+	r.SetShipTo(buildExampleContact())
+	r.SetTag(exampleReqTags)
+	r.SetThreedsecure(buildAuthThreeDSecure())
+	r.SetTransInfo(exampleReqTransInfo)
+	r.SetTransType(exampleReqTransType)
+	return r
 }
 
 func TestNewAuthRequest(t *testing.T) {
-    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
-    require.NotNil(t, model)
-    assert.Equal(t, exampleReqAmount, model.GetAmount())
-    assert.Equal(t, exampleReqCard, model.GetCardnumber())
-    assert.False(t, model.HasAirlineData())
-    assert.False(t, model.HasAvsPostcodePolicy())
-    assert.False(t, model.HasBillTo())
-    assert.False(t, model.HasCsc())
+	model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+	require.NotNil(t, model)
+	assert.Equal(t, exampleReqAmount, model.GetAmount())
+	assert.Equal(t, exampleReqCard, model.GetCardnumber())
+	assert.False(t, model.HasAirlineData())
+	assert.False(t, model.HasAvsPostcodePolicy())
+	assert.False(t, model.HasBillTo())
+	assert.False(t, model.HasCsc())
 }
 
 func TestNewAuthRequestWithDefaults(t *testing.T) {
-    model := openapiclient.NewAuthRequestWithDefaults()
-    require.NotNil(t, model)
-    assert.Equal(t, int32(0), model.GetAmount())
-    assert.Equal(t, "", model.GetCardnumber())
-    assert.False(t, model.HasAirlineData())
+	model := openapiclient.NewAuthRequestWithDefaults()
+	require.NotNil(t, model)
+	assert.Equal(t, int32(0), model.GetAmount())
+	assert.Equal(t, "", model.GetCardnumber())
+	assert.False(t, model.HasAirlineData())
 }
 
 func TestAuthRequestSetGetCycle(t *testing.T) {
-    model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
-    model.SetAirlineData(*buildExampleAdvice())
-    assert.True(t, model.HasAirlineData())
+	model := openapiclient.NewAuthRequest(exampleReqAmount, exampleReqCard, exampleReqExpMonth, exampleReqExpYear, exampleReqIdentifier, exampleReqMerchantID)
+	model.SetAirlineData(*buildExampleAdvice())
+	assert.True(t, model.HasAirlineData())
 
-    model.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
-    assert.True(t, model.HasAvsPostcodePolicy())
-    assert.Equal(t, exampleReqAvsPostcodePolicy, model.GetAvsPostcodePolicy())
+	model.SetAvsPostcodePolicy(exampleReqAvsPostcodePolicy)
+	assert.True(t, model.HasAvsPostcodePolicy())
+	assert.Equal(t, exampleReqAvsPostcodePolicy, model.GetAvsPostcodePolicy())
 
-    model.SetBillTo(buildExampleContact())
-    assert.True(t, model.HasBillTo())
+	model.SetBillTo(buildExampleContact())
+	assert.True(t, model.HasBillTo())
 
-    model.SetCsc(exampleReqCsc)
-    assert.True(t, model.HasCsc())
-    assert.Equal(t, exampleReqCsc, model.GetCsc())
+	model.SetCsc(exampleReqCsc)
+	assert.True(t, model.HasCsc())
+	assert.Equal(t, exampleReqCsc, model.GetCsc())
 
-    model.SetCscPolicy(exampleReqCscPolicy)
-    assert.True(t, model.HasCscPolicy())
-    assert.Equal(t, exampleReqCscPolicy, model.GetCscPolicy())
+	model.SetCscPolicy(exampleReqCscPolicy)
+	assert.True(t, model.HasCscPolicy())
+	assert.Equal(t, exampleReqCscPolicy, model.GetCscPolicy())
 
-    model.SetCurrency(exampleReqCurrency)
-    assert.True(t, model.HasCurrency())
-    assert.Equal(t, exampleReqCurrency, model.GetCurrency())
+	model.SetCurrency(exampleReqCurrency)
+	assert.True(t, model.HasCurrency())
+	assert.Equal(t, exampleReqCurrency, model.GetCurrency())
 
-    model.SetDuplicatePolicy(exampleReqDuplicatePolicy)
-    assert.True(t, model.HasDuplicatePolicy())
-    assert.Equal(t, exampleReqDuplicatePolicy, model.GetDuplicatePolicy())
+	model.SetDuplicatePolicy(exampleReqDuplicatePolicy)
+	assert.True(t, model.HasDuplicatePolicy())
+	assert.Equal(t, exampleReqDuplicatePolicy, model.GetDuplicatePolicy())
 
-    model.SetEventManagement(buildExampleEventData())
-    assert.True(t, model.HasEventManagement())
+	model.SetEventManagement(buildExampleEventData())
+	assert.True(t, model.HasEventManagement())
 
-    model.SetExternalMpi(buildExampleExternalMPI())
-    assert.True(t, model.HasExternalMpi())
+	model.SetExternalMpi(buildAuthExternalMPI())
+	assert.True(t, model.HasExternalMpi())
 
-    model.SetMatchAvsa(exampleReqMatchAvsa)
-    assert.True(t, model.HasMatchAvsa())
-    assert.Equal(t, exampleReqMatchAvsa, model.GetMatchAvsa())
+	model.SetMatchAvsa(exampleReqMatchAvsa)
+	assert.True(t, model.HasMatchAvsa())
+	assert.Equal(t, exampleReqMatchAvsa, model.GetMatchAvsa())
 
-    model.SetMcc6012(buildExampleMcc6012())
-    assert.True(t, model.HasMcc6012())
+	model.SetMcc6012(buildExampleMcc6012())
+	assert.True(t, model.HasMcc6012())
 
-    model.SetNameOnCard(exampleReqNameOnCard)
-    assert.True(t, model.HasNameOnCard())
-    assert.Equal(t, exampleReqNameOnCard, model.GetNameOnCard())
+	model.SetNameOnCard(exampleReqNameOnCard)
+	assert.True(t, model.HasNameOnCard())
+	assert.Equal(t, exampleReqNameOnCard, model.GetNameOnCard())
 
-    model.SetShipTo(buildExampleContact())
-    assert.True(t, model.HasShipTo())
+	model.SetShipTo(buildExampleContact())
+	assert.True(t, model.HasShipTo())
 
-    model.SetTag(exampleReqTags)
-    assert.True(t, model.HasTag())
-    assert.Equal(t, exampleReqTags, model.GetTag())
+	model.SetTag(exampleReqTags)
+	assert.True(t, model.HasTag())
+	assert.Equal(t, exampleReqTags, model.GetTag())
 
-    model.SetThreedsecure(buildExampleThreeDSecure())
-    assert.True(t, model.HasThreedsecure())
+	model.SetThreedsecure(buildAuthThreeDSecure())
+	assert.True(t, model.HasThreedsecure())
 
-    model.SetTransInfo(exampleReqTransInfo)
-    assert.True(t, model.HasTransInfo())
-    assert.Equal(t, exampleReqTransInfo, model.GetTransInfo())
+	model.SetTransInfo(exampleReqTransInfo)
+	assert.True(t, model.HasTransInfo())
+	assert.Equal(t, exampleReqTransInfo, model.GetTransInfo())
 
-    model.SetTransType(exampleReqTransType)
-    assert.True(t, model.HasTransType())
-    assert.Equal(t, exampleReqTransType, model.GetTransType())
+	model.SetTransType(exampleReqTransType)
+	assert.True(t, model.HasTransType())
+	assert.Equal(t, exampleReqTransType, model.GetTransType())
 }
 
 func TestAuthRequestJSONRoundTrip(t *testing.T) {
-    model := buildExampleAuthRequest()
-    data, err := json.Marshal(model)
-    require.NoError(t, err)
+	model := buildExampleAuthRequest()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
 
-    var unmarshalled openapiclient.AuthRequest
-    err = json.Unmarshal(data, &unmarshalled)
-    require.NoError(t, err)
-    assert.Equal(t, exampleReqAmount, unmarshalled.GetAmount())
-    assert.True(t, unmarshalled.HasTag())
-    assert.Equal(t, exampleReqTransType, unmarshalled.GetTransType())
+	var unmarshalled openapiclient.AuthRequest
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.Equal(t, exampleReqAmount, unmarshalled.GetAmount())
+	assert.True(t, unmarshalled.HasTag())
+	assert.Equal(t, exampleReqTransType, unmarshalled.GetTransType())
 }
 
 func TestAuthRequestToMap(t *testing.T) {
-    model := buildExampleAuthRequest()
-    m, err := model.ToMap()
-    require.NoError(t, err)
-    if assert.Contains(t, m, "amount") {
-        assert.Equal(t, exampleReqAmount, m["amount"])
-    }
-    if assert.Contains(t, m, "tag") {
-        assert.Equal(t, exampleReqTags, m["tag"])
-    }
+	model := buildExampleAuthRequest()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "amount") {
+		assert.Equal(t, exampleReqAmount, m["amount"])
+	}
+	if assert.Contains(t, m, "tag") {
+		assert.Equal(t, exampleReqTags, m["tag"])
+	}
 }
 
 func TestNullableAuthRequestGetSet(t *testing.T) {
-    base := buildExampleAuthRequest()
-    n := openapiclient.NullableAuthRequest{}
-    n.Set(base)
-    require.True(t, n.IsSet())
-    assert.Equal(t, base, n.Get())
+	base := buildExampleAuthRequest()
+	n := openapiclient.NullableAuthRequest{}
+	n.Set(base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, base, n.Get())
 }
 
 func TestNullableAuthRequestUnset(t *testing.T) {
-    base := buildExampleAuthRequest()
-    n := openapiclient.NewNullableAuthRequest(base)
-    require.True(t, n.IsSet())
-    n.Unset()
-    assert.False(t, n.IsSet())
-    assert.Nil(t, n.Get())
+	base := buildExampleAuthRequest()
+	n := openapiclient.NewNullableAuthRequest(base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
 }
 
 func TestNullableAuthRequestJSONRoundTrip(t *testing.T) {
-    base := buildExampleAuthRequest()
-    n := openapiclient.NewNullableAuthRequest(base)
-    data, err := json.Marshal(n)
-    require.NoError(t, err)
+	base := buildExampleAuthRequest()
+	n := openapiclient.NewNullableAuthRequest(base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
 
-    var newN openapiclient.NullableAuthRequest
-    err = json.Unmarshal(data, &newN)
-    require.NoError(t, err)
-    assert.True(t, newN.IsSet())
-    if assert.NotNil(t, newN.Get()) {
-        assert.Equal(t, exampleReqIdentifier, newN.Get().GetIdentifier())
-    }
+	var newN openapiclient.NullableAuthRequest
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleReqIdentifier, newN.Get().GetIdentifier())
+	}
 }
-

--- a/test/model/model_decision_test.go
+++ b/test/model/model_decision_test.go
@@ -18,7 +18,7 @@ var exampleAuthResult int32 = 1
 var exampleAuthCode = "A"
 var exampleAuthMsg = "Approved"
 
-func buildExampleRequestChallenged() openapiclient.RequestChallenged {
+func buildDecisionRequestChallenged() openapiclient.RequestChallenged {
 	r := openapiclient.NewRequestChallenged()
 	r.SetAcsUrl(exampleAcsURL)
 	r.SetCreq(exampleCreq)
@@ -37,7 +37,7 @@ func buildExampleAuthResp() openapiclient.AuthResponse {
 func buildExampleDecision() *openapiclient.Decision {
 	d := openapiclient.NewDecision()
 	d.SetAuthResponse(buildExampleAuthResp())
-	d.SetRequestChallenged(buildExampleRequestChallenged())
+	d.SetRequestChallenged(buildDecisionRequestChallenged())
 	return d
 }
 
@@ -64,7 +64,7 @@ func TestDecisionSetGetCycle(t *testing.T) {
 		assert.Equal(t, ar, *val)
 	}
 
-	rc := buildExampleRequestChallenged()
+	rc := buildDecisionRequestChallenged()
 	model.SetRequestChallenged(rc)
 	assert.True(t, model.HasRequestChallenged())
 	assert.Equal(t, rc, model.GetRequestChallenged())

--- a/test/model/model_direct_post_request_test.go
+++ b/test/model/model_direct_post_request_test.go
@@ -28,7 +28,7 @@ var exampleDPTag = []string{"one", "two"}
 var exampleDPTransInfo = "info"
 var exampleDPTransType = "SALE"
 
-func buildExampleContact() openapiclient.ContactDetails {
+func buildDirectPostContact() openapiclient.ContactDetails {
 	c := openapiclient.NewContactDetails()
 	c.SetAddress1("addr")
 	c.SetEmail("c@example.com")
@@ -44,7 +44,7 @@ func buildExampleThreeDS() openapiclient.ThreeDSecure {
 func buildExampleDirectPostRequest() *openapiclient.DirectPostRequest {
 	d := openapiclient.NewDirectPostRequest(exampleDPAmount, exampleDPCard, exampleDPExpMonth, exampleDPExpYear, exampleDPIdentifier, exampleDPMac)
 	d.SetAvsPostcodePolicy(exampleDPAvsPolicy)
-	d.SetBillTo(buildExampleContact())
+	d.SetBillTo(buildDirectPostContact())
 	d.SetCsc(exampleDPCsc)
 	d.SetCscPolicy(exampleDPCscPolicy)
 	d.SetCurrency(exampleDPCurrency)
@@ -54,7 +54,7 @@ func buildExampleDirectPostRequest() *openapiclient.DirectPostRequest {
 	d.SetNonce(exampleDPNonce)
 	d.SetRedirectFailure(exampleDPRedirectFail)
 	d.SetRedirectSuccess(exampleDPRedirectSuccess)
-	d.SetShipTo(buildExampleContact())
+	d.SetShipTo(buildDirectPostContact())
 	d.SetTag(exampleDPTag)
 	d.SetThreedsecure(buildExampleThreeDS())
 	d.SetTransInfo(exampleDPTransInfo)
@@ -83,7 +83,7 @@ func TestDirectPostRequestSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasAvsPostcodePolicy())
 	assert.Equal(t, exampleDPAvsPolicy, model.GetAvsPostcodePolicy())
 
-	ct := buildExampleContact()
+	ct := buildDirectPostContact()
 	model.SetBillTo(ct)
 	assert.True(t, model.HasBillTo())
 	assert.Equal(t, ct, model.GetBillTo())
@@ -124,7 +124,7 @@ func TestDirectPostRequestSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasRedirectSuccess())
 	assert.Equal(t, exampleDPRedirectSuccess, model.GetRedirectSuccess())
 
-	ship := buildExampleContact()
+	ship := buildDirectPostContact()
 	model.SetShipTo(ship)
 	assert.True(t, model.HasShipTo())
 	assert.Equal(t, ship, model.GetShipTo())

--- a/test/model/model_list_merchants_response_test.go
+++ b/test/model/model_list_merchants_response_test.go
@@ -11,7 +11,7 @@ import (
 var exampleListClientName = "ExampleClient"
 var exampleListClientID = "cli123"
 
-func buildExampleMerchant() openapiclient.Merchant {
+func buildListMerchantsMerchant() openapiclient.Merchant {
 	m := openapiclient.NewMerchant()
 	m.SetName("Shop")
 	m.SetMerchantid(99)
@@ -22,7 +22,7 @@ func buildExampleListResponse() openapiclient.ListMerchantsResponse {
 	l := openapiclient.NewListMerchantsResponse()
 	l.SetClientName(exampleListClientName)
 	l.SetClientid(exampleListClientID)
-	l.SetMerchants([]openapiclient.Merchant{buildExampleMerchant()})
+	l.SetMerchants([]openapiclient.Merchant{buildListMerchantsMerchant()})
 	return *l
 }
 
@@ -55,7 +55,7 @@ func TestListMerchantsResponseSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasClientid())
 	assert.Equal(t, exampleListClientID, model.GetClientid())
 
-	mer := buildExampleMerchant()
+	mer := buildListMerchantsMerchant()
 	model.SetMerchants([]openapiclient.Merchant{mer})
 	assert.True(t, model.HasMerchants())
 	assert.Equal(t, 1, len(model.GetMerchants()))

--- a/test/model/model_merchant_batch_report_response_test.go
+++ b/test/model/model_merchant_batch_report_response_test.go
@@ -19,14 +19,14 @@ var exampleMBRMax int32 = 10
 var exampleMBRToken = "tok"
 var exampleMBRTime = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
 
-func buildExampleNetSummary() openapiclient.NetSummaryResponse {
+func buildMBReportNetSummary() openapiclient.NetSummaryResponse {
 	n := openapiclient.NewNetSummaryResponse()
 	val := int32(100)
 	n.SetNetAmount(val)
 	return *n
 }
 
-func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+func buildMBReportMerchantBatchResponse() openapiclient.MerchantBatchResponse {
 	m := openapiclient.NewMerchantBatchResponse()
 	m.SetBatchClosed(exampleMBRTime)
 	m.SetBatchNo(exampleMBRBatchNo)
@@ -34,13 +34,13 @@ func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
 	m.SetBatchStatusCode(exampleMBRCode)
 	m.SetCurrency(exampleMBRCurrency)
 	m.SetMerchantid(exampleMBRMerchantID)
-	summary := buildExampleNetSummary()
+	summary := buildMBReportNetSummary()
 	m.SetNetSummary(summary)
 	return *m
 }
 
 func buildExampleMerchantBatchReportResponse() openapiclient.MerchantBatchReportResponse {
-	m := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	m := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildMBReportMerchantBatchResponse()})
 	m.SetCount(exampleMBRCount)
 	m.SetMaxResults(exampleMBRMax)
 	m.SetNextToken(exampleMBRToken)
@@ -48,7 +48,7 @@ func buildExampleMerchantBatchReportResponse() openapiclient.MerchantBatchReport
 }
 
 func TestNewMerchantBatchReportResponse(t *testing.T) {
-	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildMBReportMerchantBatchResponse()})
 	require.NotNil(t, model)
 	assert.Equal(t, 1, len(model.GetBatches()))
 	assert.False(t, model.HasCount())
@@ -63,7 +63,7 @@ func TestNewMerchantBatchReportResponseWithDefaults(t *testing.T) {
 }
 
 func TestMerchantBatchReportResponseSetGetCycle(t *testing.T) {
-	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()})
+	model := openapiclient.NewMerchantBatchReportResponse([]openapiclient.MerchantBatchResponse{buildMBReportMerchantBatchResponse()})
 	model.SetCount(exampleMBRCount)
 	assert.True(t, model.HasCount())
 	assert.Equal(t, exampleMBRCount, model.GetCount())

--- a/test/model/model_paylink_card_holder_test.go
+++ b/test/model/model_paylink_card_holder_test.go
@@ -1,11 +1,11 @@
 package citypay
 
 import (
-    "encoding/json"
-    openapiclient "github.com/citypay/citypay-api-client-go"
-    "github.com/stretchr/testify/assert"
-    "github.com/stretchr/testify/require"
-    "testing"
+	"encoding/json"
+	openapiclient "github.com/citypay/citypay-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 var exampleHolderAccept = "text/html"
@@ -18,137 +18,136 @@ var exampleHolderRemote = "1.1.1.1"
 var exampleHolderTitle = "Mr"
 var exampleHolderUA = "UA"
 
-func buildExamplePaylinkAddress() openapiclient.PaylinkAddress {
-    a := openapiclient.NewPaylinkAddress()
-    a.SetCountry("GB")
-    return *a
+func buildPaylinkCardHolderAddress() openapiclient.PaylinkAddress {
+	a := openapiclient.NewPaylinkAddress()
+	a.SetCountry("GB")
+	return *a
 }
 
 func buildExamplePaylinkCardHolder() openapiclient.PaylinkCardHolder {
-    h := openapiclient.NewPaylinkCardHolder()
-    h.SetAcceptHeaders(exampleHolderAccept)
-    addr := buildExamplePaylinkAddress()
-    h.SetAddress(addr)
-    h.SetCompany(exampleHolderCompany)
-    h.SetEmail(exampleHolderEmail)
-    h.SetFirstname(exampleHolderFirst)
-    h.SetLastname(exampleHolderLast)
-    h.SetMobileNo(exampleHolderMobile)
-    h.SetRemoteAddr(exampleHolderRemote)
-    h.SetTitle(exampleHolderTitle)
-    h.SetUserAgent(exampleHolderUA)
-    return *h
+	h := openapiclient.NewPaylinkCardHolder()
+	h.SetAcceptHeaders(exampleHolderAccept)
+	addr := buildPaylinkCardHolderAddress()
+	h.SetAddress(addr)
+	h.SetCompany(exampleHolderCompany)
+	h.SetEmail(exampleHolderEmail)
+	h.SetFirstname(exampleHolderFirst)
+	h.SetLastname(exampleHolderLast)
+	h.SetMobileNo(exampleHolderMobile)
+	h.SetRemoteAddr(exampleHolderRemote)
+	h.SetTitle(exampleHolderTitle)
+	h.SetUserAgent(exampleHolderUA)
+	return *h
 }
 
 func TestNewPaylinkCardHolder(t *testing.T) {
-    model := openapiclient.NewPaylinkCardHolder()
-    require.NotNil(t, model)
-    assert.False(t, model.HasEmail())
+	model := openapiclient.NewPaylinkCardHolder()
+	require.NotNil(t, model)
+	assert.False(t, model.HasEmail())
 }
 
 func TestNewPaylinkCardHolderWithDefaults(t *testing.T) {
-    model := openapiclient.NewPaylinkCardHolderWithDefaults()
-    require.NotNil(t, model)
-    assert.False(t, model.HasFirstname())
+	model := openapiclient.NewPaylinkCardHolderWithDefaults()
+	require.NotNil(t, model)
+	assert.False(t, model.HasFirstname())
 }
 
 func TestPaylinkCardHolderSetGetCycle(t *testing.T) {
-    model := openapiclient.NewPaylinkCardHolder()
-    model.SetAcceptHeaders(exampleHolderAccept)
-    assert.True(t, model.HasAcceptHeaders())
-    assert.Equal(t, exampleHolderAccept, model.GetAcceptHeaders())
+	model := openapiclient.NewPaylinkCardHolder()
+	model.SetAcceptHeaders(exampleHolderAccept)
+	assert.True(t, model.HasAcceptHeaders())
+	assert.Equal(t, exampleHolderAccept, model.GetAcceptHeaders())
 
-    addr := buildExamplePaylinkAddress()
-    model.SetAddress(addr)
-    assert.True(t, model.HasAddress())
-    assert.Equal(t, addr, model.GetAddress())
+	addr := buildPaylinkCardHolderAddress()
+	model.SetAddress(addr)
+	assert.True(t, model.HasAddress())
+	assert.Equal(t, addr, model.GetAddress())
 
-    model.SetCompany(exampleHolderCompany)
-    assert.True(t, model.HasCompany())
-    assert.Equal(t, exampleHolderCompany, model.GetCompany())
+	model.SetCompany(exampleHolderCompany)
+	assert.True(t, model.HasCompany())
+	assert.Equal(t, exampleHolderCompany, model.GetCompany())
 
-    model.SetEmail(exampleHolderEmail)
-    assert.True(t, model.HasEmail())
-    assert.Equal(t, exampleHolderEmail, model.GetEmail())
+	model.SetEmail(exampleHolderEmail)
+	assert.True(t, model.HasEmail())
+	assert.Equal(t, exampleHolderEmail, model.GetEmail())
 
-    model.SetFirstname(exampleHolderFirst)
-    assert.True(t, model.HasFirstname())
-    assert.Equal(t, exampleHolderFirst, model.GetFirstname())
+	model.SetFirstname(exampleHolderFirst)
+	assert.True(t, model.HasFirstname())
+	assert.Equal(t, exampleHolderFirst, model.GetFirstname())
 
-    model.SetLastname(exampleHolderLast)
-    assert.True(t, model.HasLastname())
-    assert.Equal(t, exampleHolderLast, model.GetLastname())
+	model.SetLastname(exampleHolderLast)
+	assert.True(t, model.HasLastname())
+	assert.Equal(t, exampleHolderLast, model.GetLastname())
 
-    model.SetMobileNo(exampleHolderMobile)
-    assert.True(t, model.HasMobileNo())
-    assert.Equal(t, exampleHolderMobile, model.GetMobileNo())
+	model.SetMobileNo(exampleHolderMobile)
+	assert.True(t, model.HasMobileNo())
+	assert.Equal(t, exampleHolderMobile, model.GetMobileNo())
 
-    model.SetRemoteAddr(exampleHolderRemote)
-    assert.True(t, model.HasRemoteAddr())
-    assert.Equal(t, exampleHolderRemote, model.GetRemoteAddr())
+	model.SetRemoteAddr(exampleHolderRemote)
+	assert.True(t, model.HasRemoteAddr())
+	assert.Equal(t, exampleHolderRemote, model.GetRemoteAddr())
 
-    model.SetTitle(exampleHolderTitle)
-    assert.True(t, model.HasTitle())
-    assert.Equal(t, exampleHolderTitle, model.GetTitle())
+	model.SetTitle(exampleHolderTitle)
+	assert.True(t, model.HasTitle())
+	assert.Equal(t, exampleHolderTitle, model.GetTitle())
 
-    model.SetUserAgent(exampleHolderUA)
-    assert.True(t, model.HasUserAgent())
-    assert.Equal(t, exampleHolderUA, model.GetUserAgent())
+	model.SetUserAgent(exampleHolderUA)
+	assert.True(t, model.HasUserAgent())
+	assert.Equal(t, exampleHolderUA, model.GetUserAgent())
 }
 
 func TestPaylinkCardHolderJSONRoundTrip(t *testing.T) {
-    model := buildExamplePaylinkCardHolder()
-    data, err := json.Marshal(model)
-    require.NoError(t, err)
+	model := buildExamplePaylinkCardHolder()
+	data, err := json.Marshal(model)
+	require.NoError(t, err)
 
-    var unmarshalled openapiclient.PaylinkCardHolder
-    err = json.Unmarshal(data, &unmarshalled)
-    require.NoError(t, err)
-    assert.True(t, unmarshalled.HasRemoteAddr())
-    assert.Equal(t, exampleHolderRemote, unmarshalled.GetRemoteAddr())
+	var unmarshalled openapiclient.PaylinkCardHolder
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+	assert.True(t, unmarshalled.HasRemoteAddr())
+	assert.Equal(t, exampleHolderRemote, unmarshalled.GetRemoteAddr())
 }
 
 func TestPaylinkCardHolderToMap(t *testing.T) {
-    model := buildExamplePaylinkCardHolder()
-    m, err := model.ToMap()
-    require.NoError(t, err)
-    if assert.Contains(t, m, "accept_headers") {
-        assert.Equal(t, &exampleHolderAccept, m["accept_headers"])
-    }
-    if assert.Contains(t, m, "company") {
-        assert.Equal(t, &exampleHolderCompany, m["company"])
-    }
+	model := buildExamplePaylinkCardHolder()
+	m, err := model.ToMap()
+	require.NoError(t, err)
+	if assert.Contains(t, m, "accept_headers") {
+		assert.Equal(t, &exampleHolderAccept, m["accept_headers"])
+	}
+	if assert.Contains(t, m, "company") {
+		assert.Equal(t, &exampleHolderCompany, m["company"])
+	}
 }
 
 func TestNullablePaylinkCardHolderGetSet(t *testing.T) {
-    base := buildExamplePaylinkCardHolder()
-    n := openapiclient.NullablePaylinkCardHolder{}
-    n.Set(&base)
-    require.True(t, n.IsSet())
-    assert.Equal(t, &base, n.Get())
+	base := buildExamplePaylinkCardHolder()
+	n := openapiclient.NullablePaylinkCardHolder{}
+	n.Set(&base)
+	require.True(t, n.IsSet())
+	assert.Equal(t, &base, n.Get())
 }
 
 func TestNullablePaylinkCardHolderUnset(t *testing.T) {
-    base := buildExamplePaylinkCardHolder()
-    n := openapiclient.NewNullablePaylinkCardHolder(&base)
-    require.True(t, n.IsSet())
-    n.Unset()
-    assert.False(t, n.IsSet())
-    assert.Nil(t, n.Get())
+	base := buildExamplePaylinkCardHolder()
+	n := openapiclient.NewNullablePaylinkCardHolder(&base)
+	require.True(t, n.IsSet())
+	n.Unset()
+	assert.False(t, n.IsSet())
+	assert.Nil(t, n.Get())
 }
 
 func TestNullablePaylinkCardHolderJSONRoundTrip(t *testing.T) {
-    base := buildExamplePaylinkCardHolder()
-    n := openapiclient.NewNullablePaylinkCardHolder(&base)
-    data, err := json.Marshal(n)
-    require.NoError(t, err)
+	base := buildExamplePaylinkCardHolder()
+	n := openapiclient.NewNullablePaylinkCardHolder(&base)
+	data, err := json.Marshal(n)
+	require.NoError(t, err)
 
-    var newN openapiclient.NullablePaylinkCardHolder
-    err = json.Unmarshal(data, &newN)
-    require.NoError(t, err)
-    assert.True(t, newN.IsSet())
-    if assert.NotNil(t, newN.Get()) {
-        assert.Equal(t, exampleHolderFirst, newN.Get().GetFirstname())
-    }
+	var newN openapiclient.NullablePaylinkCardHolder
+	err = json.Unmarshal(data, &newN)
+	require.NoError(t, err)
+	assert.True(t, newN.IsSet())
+	if assert.NotNil(t, newN.Get()) {
+		assert.Equal(t, exampleHolderFirst, newN.Get().GetFirstname())
+	}
 }
-

--- a/test/model/model_payment_intent_test.go
+++ b/test/model/model_payment_intent_test.go
@@ -20,7 +20,7 @@ var exampleIntentTransInfo = "info"
 var exampleIntentTransType = "SALE"
 var exampleIntentTag = []string{"t1", "t2"}
 
-func buildExampleContact() openapiclient.ContactDetails {
+func buildIntentContact() openapiclient.ContactDetails {
 	c := openapiclient.NewContactDetails()
 	c.SetAddress1("street")
 	c.SetEmail("x@example.com")
@@ -30,13 +30,13 @@ func buildExampleContact() openapiclient.ContactDetails {
 func buildExamplePaymentIntent() openapiclient.PaymentIntent {
 	p := openapiclient.NewPaymentIntent(exampleIntentAmount, exampleIntentIdentifier)
 	p.SetAvsPostcodePolicy(exampleIntentAvsPolicy)
-	p.SetBillTo(buildExampleContact())
+	p.SetBillTo(buildIntentContact())
 	p.SetCsc(exampleIntentCsc)
 	p.SetCscPolicy(exampleIntentCscPolicy)
 	p.SetCurrency(exampleIntentCurrency)
 	p.SetDuplicatePolicy(exampleIntentDupPolicy)
 	p.SetMatchAvsa(exampleIntentMatchAvsa)
-	p.SetShipTo(buildExampleContact())
+	p.SetShipTo(buildIntentContact())
 	p.SetTag(exampleIntentTag)
 	p.SetTransInfo(exampleIntentTransInfo)
 	p.SetTransType(exampleIntentTransType)
@@ -64,7 +64,7 @@ func TestPaymentIntentSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasAvsPostcodePolicy())
 	assert.Equal(t, exampleIntentAvsPolicy, model.GetAvsPostcodePolicy())
 
-	ct := buildExampleContact()
+	ct := buildIntentContact()
 	model.SetBillTo(ct)
 	assert.True(t, model.HasBillTo())
 	assert.Equal(t, ct, model.GetBillTo())
@@ -89,7 +89,7 @@ func TestPaymentIntentSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasMatchAvsa())
 	assert.Equal(t, exampleIntentMatchAvsa, model.GetMatchAvsa())
 
-	ship := buildExampleContact()
+	ship := buildIntentContact()
 	model.SetShipTo(ship)
 	assert.True(t, model.HasShipTo())
 	assert.Equal(t, ship, model.GetShipTo())

--- a/test/model/model_process_batch_request_test.go
+++ b/test/model/model_process_batch_request_test.go
@@ -12,7 +12,7 @@ var exampleProcessDate = "2024-01-01"
 var exampleProcessID int32 = 7
 var exampleProcessClient = "cli"
 
-func buildExampleBatchTransaction() openapiclient.BatchTransaction {
+func buildProcessBatchTransaction() openapiclient.BatchTransaction {
 	b := openapiclient.NewBatchTransaction("acc", 10)
 	b.SetIdentifier("id")
 	b.SetMerchantid(1)
@@ -20,7 +20,7 @@ func buildExampleBatchTransaction() openapiclient.BatchTransaction {
 }
 
 func buildExampleProcessBatchRequest() openapiclient.ProcessBatchRequest {
-	p := openapiclient.NewProcessBatchRequest(exampleProcessDate, exampleProcessID, []openapiclient.BatchTransaction{buildExampleBatchTransaction()})
+	p := openapiclient.NewProcessBatchRequest(exampleProcessDate, exampleProcessID, []openapiclient.BatchTransaction{buildProcessBatchTransaction()})
 	p.SetClientAccountId(exampleProcessClient)
 	return *p
 }
@@ -45,7 +45,7 @@ func TestProcessBatchRequestSetGetCycle(t *testing.T) {
 	assert.True(t, model.HasClientAccountId())
 	assert.Equal(t, exampleProcessClient, model.GetClientAccountId())
 
-	tx := buildExampleBatchTransaction()
+	tx := buildProcessBatchTransaction()
 	model.SetTransactions([]openapiclient.BatchTransaction{tx})
 	assert.Len(t, model.GetTransactions(), 1)
 }

--- a/test/model/model_remittance_report_response_test.go
+++ b/test/model/model_remittance_report_response_test.go
@@ -13,26 +13,26 @@ var exampleRemitRespCount int32 = 2
 var exampleRemitRespMax int32 = 10
 var exampleRemitRespNext = "next"
 
-func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+func buildRRMerchantBatchResponse() openapiclient.MerchantBatchResponse {
 	m := openapiclient.NewMerchantBatchResponse()
 	m.SetBatchId(1)
 	return *m
 }
 
-func buildExampleRemittanceDataSlice() []openapiclient.RemittanceData {
+func buildRRRemittanceDataSlice() []openapiclient.RemittanceData {
 	r := openapiclient.NewRemittanceData()
 	r.SetDateCreated(time.Now())
 	return []openapiclient.RemittanceData{*r}
 }
 
-func buildExampleRemittedClientData() openapiclient.RemittedClientData {
-	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()}, buildExampleRemittanceDataSlice())
+func buildRRRemittedClientData() openapiclient.RemittedClientData {
+	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildRRMerchantBatchResponse()}, buildRRRemittanceDataSlice())
 	d.SetClientid("c1")
 	return *d
 }
 
 func buildExampleRemittanceReportResponse() openapiclient.RemittanceReportResponse {
-	r := openapiclient.NewRemittanceReportResponse([]openapiclient.RemittedClientData{buildExampleRemittedClientData()})
+	r := openapiclient.NewRemittanceReportResponse([]openapiclient.RemittedClientData{buildRRRemittedClientData()})
 	r.SetCount(exampleRemitRespCount)
 	r.SetMaxResults(exampleRemitRespMax)
 	r.SetNextToken(exampleRemitRespNext)

--- a/test/model/model_remitted_client_data_test.go
+++ b/test/model/model_remitted_client_data_test.go
@@ -13,7 +13,7 @@ var exampleRemittedClientID = "cid"
 var exampleRemittedDate = "2024-01-02"
 var exampleRemittedNet int32 = 50
 
-func buildExampleMerchantBatchResponse() openapiclient.MerchantBatchResponse {
+func buildRCDMerchantBatchResponse() openapiclient.MerchantBatchResponse {
 	m := openapiclient.NewMerchantBatchResponse()
 	m.SetBatchId(1)
 	return *m
@@ -26,7 +26,7 @@ func buildExampleRemittanceDataSlice() []openapiclient.RemittanceData {
 }
 
 func buildExampleRemittedClientData() openapiclient.RemittedClientData {
-	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildExampleMerchantBatchResponse()}, buildExampleRemittanceDataSlice())
+	d := openapiclient.NewRemittedClientData([]openapiclient.MerchantBatchResponse{buildRCDMerchantBatchResponse()}, buildExampleRemittanceDataSlice())
 	d.SetClientid(exampleRemittedClientID)
 	d.SetDate(&exampleRemittedDate)
 	d.SetNetAmount(exampleRemittedNet)


### PR DESCRIPTION
## Summary
- rename test helper functions in `test/model` so their names are unique

## Testing
- `go test ./...` *(fails: blocked from downloading modules)*

------
https://chatgpt.com/codex/tasks/task_b_68778818be3883319fae3f5bdb36470a